### PR TITLE
ci: cost-saver matrix (PR-only full 3-OS + concurrency cancel)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,16 +34,26 @@ on:
 permissions:
   contents: read
 
+# Cost control: cancel an in-flight run when a newer commit lands on the same
+# ref, so a burst of pushes does not fan out N parallel matrix runs against the
+# shared org Actions-minutes quota. Per-ref group, so a PR and a branch push do
+# not cancel each other.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: test (${{ matrix.os }})
     strategy:
-      fail-fast: false # we want to see ALL three OS legs, not just the first red one
+      fail-fast: false # we want to see ALL OS legs on a PR, not just the first red one
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        # Cost control: the full 3-OS matrix runs ONLY on pull_request, where a
+        # cross-platform regression must be caught before merge. On push (main /
+        # branch) we run ONLY ubuntu-latest -- macOS bills at 10x and Windows at
+        # 2x the Linux minute rate, and the BLOCKING min-passed floor is the
+        # Linux leg anyway. So a routine push costs ~1 leg instead of ~13x.
+        os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
 


### PR DESCRIPTION
## Why
The shared **org** Actions-minutes quota is exhausted (every recent run is a billing `startup_failure`). Root cause: routine pushes fan out the full 3-OS matrix, and **macOS bills at 10x / Windows at 2x** the Linux minute rate -- one push burns ~13 Linux-equivalent legs. With a burst of agent-swarm pushes that drains the quota fast.

## What (no coverage loss)
- **Event-conditional matrix**: full `ubuntu + macOS + windows` runs **only on `pull_request`** (where cross-platform regressions must be caught before merge). A **push** runs **only `ubuntu-latest`** -- which is the BLOCKING min-passed floor leg anyway. Routine push cost drops from ~13x to ~1x.
- **`concurrency` group** (per ref) with `cancel-in-progress: true`: a newer commit cancels the in-flight run instead of stacking parallel matrix runs.

## Scope
Pure cost reduction. The floor fix (`--continue-on-collection-errors` + test-only deps) is **already present** in this repo's `ci.yml`.

## Verification
**Not merging yet** -- the org Actions quota is currently billing-blocked, so CI cannot run to prove this. Merge once Actions is unblocked and this PR's checks go green.