### PR TITLE
ci: drop stale wip branch from push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ on:
   push:
     branches:
       - main
-      - "wip/cross-platform-cloud-first-20260529"
   pull_request:
 
 permissions:


### PR DESCRIPTION
Removes the internal working-branch ref `wip/cross-platform-cloud-first-20260529` from the CI push trigger. It does not exist in this distribution repo and would leak an internal branch name into a repo going public. CI still runs on push to `main` + all PRs. Pure CI-config; no test-logic change.