### PR TITLE
fix(wiki): align bundled vault entity taxonomy

### DIFF
--- a/wiki/obsidian-vault/schema.md
+++ b/wiki/obsidian-vault/schema.md
@@ -65,7 +65,7 @@ Required frontmatter:
 ```yaml
 ---
 type: entity
-entity_kind: person | tool | repository | service | device
+entity_kind: person | tool | repository | service | device | asset | vehicle | place | organization
 slug: <slug>
 aliases: [list, of, alt, names]
 created: YYYY-MM-DD


### PR DESCRIPTION
## Summary

- align the tracked starter vault schema with the canonical packaged schema
- avoid an automatic first-start schema migration dirtying a source installation
- keep the expanded asset, vehicle, place, and organization entity kinds documented consistently

## Validation

- `pytest -q tests/unit/memory/wiki/test_schema_upgrade.py tests/unit/test_no_personal_state_tracked.py`
- `python scripts/ci/check_no_new_german.py`
- `python scripts/ci/check_no_private_keys.py`
- pre-push repository gates, including boot budget