### PR TITLE
Release v1.1.2: cross-platform reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,44 @@
 
 All notable changes in Personal Jarvis.
 
-Format based on [Keep a Changelog](https://keepachangelog.com/de/1.1.0/),
-versioning per [SemVer](https://semver.org/lang/de/).
+Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+versioning per [SemVer](https://semver.org/).
 
 ---
 
 ## [Unreleased]
 
+## [1.1.2] — 2026-07-20
+
 ### Fixed
 
+- **Audio input and voice-output devices now stay accurate after hardware
+  changes.** The settings picker refreshes safely when microphones, speakers,
+  headsets, or virtual devices are connected or removed, shows the actual
+  input/output devices on the current OS, and preserves a valid selection
+  without requiring an app restart.
+- **Wake, push-to-talk, and realtime voice recover instead of going silent.**
+  Wake-microphone reopen failures and stalled reads now trigger bounded
+  recovery, push-to-talk release is reliable, microphone-send stalls rebuild
+  cleanly, stale rebuild timeouts are ignored, and novel follow-up speech is
+  preserved while self-playback and barge-in are cancelled atomically.
+- **Fresh-install model choices and fallbacks are respected.** A model selected
+  through the provider UI is no longer overwritten when no explicit router
+  section exists, same-provider fallback models remain available, coding-CLI
+  readiness/login state is truthful, and tests no longer inherit a maintainer
+  machine's private provider configuration or credentials.
+- **Mission results and desktop workflows fail honestly and remain usable.**
+  Mission outcome handling, connected coding-CLI flows, saved-file drag-out,
+  and macOS Computer-Use indicator behavior were hardened across success,
+  retry, and unavailable-capability paths.
+- **Wiki capture uses one canonical entity taxonomy.** Bundled vault templates,
+  graph ingestion, and desktop rendering now agree on entity types, while
+  newly captured facts surface consistently in the graph.
+- **Cross-platform setup and validation are more portable.** Non-Windows
+  Registry operations return an explicit unsupported result, subprocess and
+  stdio checks recognize the running virtual-environment interpreter without
+  relying on PATH, and simulated Windows paths keep Windows separators on
+  macOS/Linux CI. Skill-draft traversal checks now reject both separator styles.
 - **macOS: Jarvis Bar hover controls now react and remain stable.** The
   non-activating Qt panel could miss mouse-move events, while replacing its
   alpha input mask emitted a false leave as the pill expanded. The result was

--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -1,3 +1,3 @@
 """Personal Jarvis — a voice-driven, cross-platform meta-orchestrator."""
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/jarvis/admin/executor.py
+++ b/jarvis/admin/executor.py
@@ -436,7 +436,14 @@ class AdminExecutor:
     # ------------------------------------------------------------------
 
     async def _do_read_registry(self, op: ReadRegistryOp) -> dict[str, Any]:
-        import winreg
+        try:
+            import winreg
+        except ImportError:
+            return {
+                "success": False,
+                "error_code": "registry_unsupported",
+                "error_message": "Windows Registry is unavailable on this platform.",
+            }
 
         def _do_read() -> dict[str, Any]:
             hive = _hive_constant(op.hive)
@@ -487,7 +494,14 @@ class AdminExecutor:
         *,
         hive_override: str | None,
     ) -> dict[str, Any]:
-        import winreg
+        try:
+            import winreg
+        except ImportError:
+            return {
+                "success": False,
+                "error_code": "registry_unsupported",
+                "error_message": "Windows Registry is unavailable on this platform.",
+            }
 
         hive_name = hive_override if hive_override else "HKCU"
 
@@ -768,4 +782,3 @@ class AdminExecutor:
             "error_message": (stderr or stdout) if not success else None,
             "result": {"exit_code": rc, "action": op.action, "label": op.label},
         }
-

--- a/jarvis/brain/manager.py
+++ b/jarvis/brain/manager.py
@@ -2177,12 +2177,20 @@ class BrainManager:
         #   in the in-memory config before _fast_model/_deep_model could read it
         #   (live forensic 2026-06-29: ~5€ OpenRouter key drained on Opus + Haiku).
         #   AP-21/AP-22, open-source single-key §3.
-        # - If no override: respect tier_cfg.model, then fall back to the default.
+        # - If no override: respect tier_cfg.model, then the provider pick, then
+        #   fall back to the default. Fresh installs have no [brain.router]
+        #   block, so ignoring providers.<name>.model here would overwrite the
+        #   model selected in the UI on every boot.
         if provider_override:
             override_pc = (local_config.brain.providers or {}).get(effective_provider)
             explicit_model = getattr(override_pc, "model", None) or None
         else:
-            explicit_model = tier_cfg.model
+            provider_pc = (local_config.brain.providers or {}).get(effective_provider)
+            explicit_model = (
+                tier_cfg.model
+                or getattr(provider_pc, "model", None)
+                or None
+            )
         resolved_model = _resolve_tier_model(tier, effective_provider, explicit_model)
         if resolved_model and effective_provider in (local_config.brain.providers or {}):
             local_config.brain.providers[effective_provider].model = resolved_model
@@ -7077,8 +7085,6 @@ class BrainManager:
         # generic cross-provider probing so runtime matches healthcheck order.
         available = set(self._registry.available())
         for name, configured_model in self._configured_fallbacks:
-            if name == active:
-                continue
             if name not in available:
                 continue
             m_fast = self._fast_model(name)

--- a/jarvis/core/process_utils.py
+++ b/jarvis/core/process_utils.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 if sys.platform == "win32":
     NO_WINDOW_CREATIONFLAGS: int = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
@@ -55,7 +56,18 @@ def resolve_executable(name: str) -> str:
     if not name:
         return name
     resolved = shutil.which(name)
-    return resolved or name
+    if resolved:
+        return resolved
+
+    # A caller may launch the app as ``.venv/bin/python`` without activating
+    # that environment, so the running interpreter's directory is absent from
+    # PATH. Treat its exact basename as resolvable even in that valid setup.
+    if (
+        Path(name).name == name
+        and Path(sys.executable).name.casefold() == name.casefold()
+    ):
+        return str(Path(sys.executable).resolve())
+    return name
 
 
 __all__ = ["NO_WINDOW_CREATIONFLAGS", "resolve_executable"]

--- a/jarvis/google_cli/pty_runner.py
+++ b/jarvis/google_cli/pty_runner.py
@@ -18,6 +18,7 @@ token is never read to make our own HTTP request.
 """
 from __future__ import annotations
 
+import ntpath
 import os
 import re
 import sys
@@ -108,18 +109,18 @@ def repair_agy_path(
         return path or ""
     root = system_root or os.environ.get("SystemRoot") or os.environ.get("windir") or r"C:\Windows"
     needed = [
-        os.path.join(root, "System32"),
-        os.path.join(root, "System32", "Wbem"),
+        ntpath.join(root, "System32"),
+        ntpath.join(root, "System32", "Wbem"),
         root,
     ]
     if node_dir:
         needed.append(node_dir)
-    parts = [p for p in (path or "").split(os.pathsep) if p]
-    have = {p.rstrip("\\").lower() for p in parts}
-    prefix = [d for d in needed if d.rstrip("\\").lower() not in have]
+    parts = [p for p in (path or "").split(";") if p]
+    have = {p.rstrip("\\/").lower() for p in parts}
+    prefix = [d for d in needed if d.rstrip("\\/").lower() not in have]
     if not prefix:
         return path or ""
-    return os.pathsep.join([*prefix, *parts])
+    return ";".join([*prefix, *parts])
 
 
 @dataclass(frozen=True)

--- a/jarvis/setup/obsidian.py
+++ b/jarvis/setup/obsidian.py
@@ -14,8 +14,8 @@ Scope of this module:
     (case-insensitive, trailing-slash tolerant — Windows-friendly).
 
 What this module deliberately does NOT do:
-  * No mutation of ``obsidian.json`` (that lives in Sub-Agent 2's writer).
-  * No FastAPI / HTTP surface (that is Sub-Agent 3's route).
+  * No mutation of ``obsidian.json`` (that belongs to the setup writer).
+  * No FastAPI / HTTP surface (that belongs to the setup route).
   * No subprocess launches of Obsidian.exe.
   * No network calls.
 
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import json
 import logging
+import ntpath
 import os
 import secrets
 import shutil
@@ -118,16 +119,18 @@ def _candidate_install_paths(platform: str | None = None) -> list[Path]:
 
     local_appdata = os.environ.get("LOCALAPPDATA")
     if local_appdata:
-        candidates.append(Path(local_appdata) / "Programs" / "Obsidian" / "Obsidian.exe")
+        candidates.append(
+            Path(ntpath.join(local_appdata, "Programs", "Obsidian", "Obsidian.exe"))
+        )
 
     program_files = os.environ.get("PROGRAMFILES")
     if program_files:
-        candidates.append(Path(program_files) / "Obsidian" / "Obsidian.exe")
+        candidates.append(Path(ntpath.join(program_files, "Obsidian", "Obsidian.exe")))
 
     # Note: env var name on Windows literally contains parentheses.
     program_files_x86 = os.environ.get("PROGRAMFILES(X86)")
     if program_files_x86:
-        candidates.append(Path(program_files_x86) / "Obsidian" / "Obsidian.exe")
+        candidates.append(Path(ntpath.join(program_files_x86, "Obsidian", "Obsidian.exe")))
 
     return candidates
 
@@ -155,7 +158,7 @@ def _probe_uninstall_registry() -> Path | None:
             continue
         if not install_location:
             continue
-        exe = Path(install_location) / "Obsidian.exe"
+        exe = Path(ntpath.join(install_location, "Obsidian.exe"))
         if exe.exists():
             return exe
     return None

--- a/jarvis/skills/authoring/draft_writer.py
+++ b/jarvis/skills/authoring/draft_writer.py
@@ -65,7 +65,11 @@ def _resolved_target(slug: str, root: Path | None = None) -> Path:
     slug validator were bypassed.
     """
     base = root.resolve() if root is not None else _resolve_user_skills_root()
-    candidate = (base / slug).resolve()
+    # Treat both separator styles as path syntax on every host. Without this,
+    # a Windows traversal such as ``..\..\outside`` is only a literal filename
+    # when a security test runs on POSIX, even though it escapes after the same
+    # artifact is moved to Windows.
+    candidate = (base / slug.replace("\\", "/")).resolve()
     try:
         candidate.relative_to(base)
     except ValueError as exc:

--- a/jarvis/ui/web/marketplace_routes.py
+++ b/jarvis/ui/web/marketplace_routes.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -19,6 +20,7 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 
+from jarvis.core.process_utils import resolve_executable
 from jarvis.marketplace.auth import (
     DcrConfig,
     DeviceFlowConfig,
@@ -205,12 +207,12 @@ def _mcp_live(
                 return False, hint
         return True, None
     if transport == "stdio":
-        import shutil
-
         install = mcp.get("install") or []
         launcher = str(install[0]) if install else ""
-        if launcher and shutil.which(launcher):
-            return True, None
+        if launcher:
+            resolved = resolve_executable(launcher)
+            if resolved != launcher or Path(resolved).is_file():
+                return True, None
         return False, (launcher or None)
     return False, None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "personal-jarvis"
-version = "1.1.1"
+version = "1.1.2"
 description = "Voice-driven meta-orchestrator that turns one spoken request into a fleet of self-checking AI agents"
 requires-python = ">=3.11,<3.15"
 readme = "README.md"
@@ -624,12 +624,12 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 pythonpath = ["."]
 markers = [
-    "phase5: Phase-5-Integration-Tests (isoliert fahrbar via `pytest -m phase5`).",
+    "phase5: Phase 5 integration tests (run in isolation with `pytest -m phase5`).",
     "skip_ci: tests that need real desktop/admin/live clicking — not run in CI.",
-    "e2e: Phase-7-End-to-End-Tests (Plan-§7.6, manuell via `pytest -m e2e`).",
-    "voice_latency: Phase-L Voice-Latency-Tests (Plan §6.1; manuell via `pytest -m voice_latency`).",
-    "eval: Phase-8.6 Eval-Harness — Golden-Query-Suite (manuell via `pytest -m eval`).",
-    "slow: Lang laufende Tests (Eval, E2E) — vom Standard-Run via `pytest -m 'not slow'` ausgeschlossen.",
+    "e2e: Phase 7 end-to-end tests (Plan §7.6; run manually with `pytest -m e2e`).",
+    "voice_latency: Phase L voice-latency tests (Plan §6.1; run manually with `pytest -m voice_latency`).",
+    "eval: Phase 8.6 evaluation harness and golden-query suite (run manually with `pytest -m eval`).",
+    "slow: Long-running evaluation and E2E tests excluded by `pytest -m 'not slow'`.",
     "integration: Integration tests that spawn real subprocesses or hit live external services (e.g. Codex CLI ChatGPT OAuth). Self-skip when prerequisites are missing; run explicitly via `pytest -m integration`.",
     "real_tcc_gate: opts a Computer-Use test back into the real macOS Screen-Recording gate that tests/unit/cu/conftest.py neutralizes by default.",
 ]

--- a/tests/contract/test_stt_protocol.py
+++ b/tests/contract/test_stt_protocol.py
@@ -18,7 +18,6 @@ import inspect
 import io
 import json
 import wave
-from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from importlib import metadata as importlib_metadata
 from pathlib import Path
@@ -170,9 +169,7 @@ def test_groq_transcribe_uploads_wav_and_parses_response(monkeypatch):
     provider, _ = _build_groq(monkeypatch, handler)
 
     chunks = [FakeChunk(pcm=_fake_pcm(0.5))]
-    result = asyncio.get_event_loop().run_until_complete(
-        provider.transcribe(_async_iter(chunks))
-    )
+    result = asyncio.run(provider.transcribe(_async_iter(chunks)))
 
     assert result.text == "Hallo Welt"
     assert result.language == "de"
@@ -198,9 +195,7 @@ def test_groq_empty_audio_returns_empty_transcript_without_http(monkeypatch):
         return httpx.Response(500, text="should not be called")
 
     provider, _ = _build_groq(monkeypatch, handler)
-    result = asyncio.get_event_loop().run_until_complete(
-        provider.transcribe(_async_iter([]))
-    )
+    result = asyncio.run(provider.transcribe(_async_iter([])))
     assert result.text == ""
     assert result.confidence == 0.0
     assert calls["n"] == 0
@@ -219,7 +214,7 @@ def test_groq_stream_transcribe_yields_single_final(monkeypatch):
             out.append(t)
         return out
 
-    results = asyncio.get_event_loop().run_until_complete(drive())
+    results = asyncio.run(drive())
     assert len(results) == 1
     assert results[0].text == "Test"
     assert results[0].language == "en"
@@ -241,9 +236,7 @@ def test_groq_raises_when_api_key_missing(monkeypatch):
     provider = GroqWhisperAPI(http_client=_make_mock_client(handler))
     chunks = [FakeChunk(pcm=_fake_pcm(0.2))]
     with pytest.raises(RuntimeError, match="GROQ_API_KEY"):
-        asyncio.get_event_loop().run_until_complete(
-            provider.transcribe(_async_iter(chunks))
-        )
+        asyncio.run(provider.transcribe(_async_iter(chunks)))
 
 
 def test_groq_wraps_pcm_into_valid_wav_container(monkeypatch):
@@ -256,7 +249,7 @@ def test_groq_wraps_pcm_into_valid_wav_container(monkeypatch):
 
     provider, _ = _build_groq(monkeypatch, handler)
     chunks = [FakeChunk(pcm=_fake_pcm(0.4))]
-    asyncio.get_event_loop().run_until_complete(provider.transcribe(_async_iter(chunks)))
+    asyncio.run(provider.transcribe(_async_iter(chunks)))
 
     # Extract the WAV blob from the multipart body and re-parse it with `wave`.
     body = captured["body"]
@@ -282,9 +275,7 @@ def test_groq_segmentless_response_confidence_defaults(monkeypatch):
 
     provider, _ = _build_groq(monkeypatch, handler)
     chunks = [FakeChunk(pcm=_fake_pcm(0.2))]
-    result = asyncio.get_event_loop().run_until_complete(
-        provider.transcribe(_async_iter(chunks))
-    )
+    result = asyncio.run(provider.transcribe(_async_iter(chunks)))
     assert result.text == "hi"
     assert result.language == "en"
     assert result.confidence == 1.0

--- a/tests/integration/test_ack_flow.py
+++ b/tests/integration/test_ack_flow.py
@@ -137,6 +137,9 @@ async def test_happy_path_flash_brain_publishes_preamble() -> None:
 async def test_happy_path_announcement_handler_calls_tts_once() -> None:
     """The _on_announcement handler is the entry point into TTS — verify the
     preamble flows through it exactly once and reaches synthesize()."""
+    async def _not_delivered_via_realtime(*_args: Any, **_kwargs: Any) -> bool:
+        return False
+
     stub = SimpleNamespace(
         _ack_brain=MagicMock(),  # truthy → suppression branch skipped for ack_brain
         _player=MagicMock(),
@@ -147,6 +150,10 @@ async def test_happy_path_announcement_handler_calls_tts_once() -> None:
         _output_language=lambda lang, text: lang,  # language resolver
         _emit_spoken=lambda *a, **kw: None,         # session-log hook
         _bcp47=lambda lang: lang,                   # BCP-47 converter
+        _deliver_announcement_via_realtime=_not_delivered_via_realtime,
+        _realtime_session_owns_voice=lambda: False,
+        _register_assistant_speech=lambda _text: None,
+        _playback_confirmed=lambda _result: True,
     )
     stub._tts.synthesize = MagicMock(return_value=iter([b"audio-chunk"]))
 

--- a/tests/integration/test_autostart_route.py
+++ b/tests/integration/test_autostart_route.py
@@ -15,7 +15,7 @@ from fastapi.testclient import TestClient
 
 import jarvis.autostart as autostart
 import jarvis.platform.capabilities as caps_mod
-from jarvis.autostart.protocol import AutostartStatus
+from jarvis.autostart.protocol import AutostartStatus, LaunchSpec
 from jarvis.core.bus import EventBus
 from jarvis.core.config import JarvisConfig
 from jarvis.platform.capabilities import Capabilities
@@ -81,6 +81,15 @@ def server() -> Iterator[WebServer]:
 def fake_manager(monkeypatch: pytest.MonkeyPatch) -> _FakeManager:
     mgr = _FakeManager(supported=True)
     monkeypatch.setattr(autostart, "make_autostart_manager", lambda caps: mgr)
+    monkeypatch.setattr(
+        autostart,
+        "resolve_launch_spec",
+        lambda _cfg: LaunchSpec(
+            program="/usr/bin/python3",
+            args=("-m", "jarvis.ui.web.launcher"),
+            working_dir="/fake/personal-jarvis",
+        ),
+    )
     monkeypatch.setattr(caps_mod, "detect_capabilities", lambda: _caps())
     return mgr
 

--- a/tests/integration/test_docs_routes.py
+++ b/tests/integration/test_docs_routes.py
@@ -277,15 +277,16 @@ def test_open_doc_in_editor(
     monkeypatch,
     doc_root: Path,
 ) -> None:
-    """Patch the Windows-only launcher and verify path resolution."""
-    import os as os_module
+    """Patch the cross-platform launcher and verify path resolution."""
+    from jarvis.platform import open_path
 
-    calls: list[str] = []
+    calls: list[Path] = []
 
-    def fake_startfile(path: str) -> None:
+    def fake_open_file(path: Path) -> bool:
         calls.append(path)
+        return True
 
-    monkeypatch.setattr(os_module, "startfile", fake_startfile, raising=False)
+    monkeypatch.setattr(open_path, "open_file", fake_open_file)
     resp = client.post("/api/docs/router-discipline/open")
     assert resp.status_code == 200
     data = resp.json()
@@ -293,6 +294,7 @@ def test_open_doc_in_editor(
     assert data["path"] == "concept-routing.md"
     assert str(doc_root) not in client.get("/api/docs").text
     assert len(calls) == 1
+    assert calls[0] == (doc_root / "docs" / "concept-routing.md").resolve()
 
 
 def test_open_doc_in_editor_unknown_slug(client: TestClient) -> None:

--- a/tests/integration/test_phase1a_smoke.py
+++ b/tests/integration/test_phase1a_smoke.py
@@ -48,7 +48,9 @@ def test_config():
 async def test_webserver_starts_and_stops(test_config):
     WebServer = _try_import_webserver()
     srv = WebServer(test_config)
-    await srv.start()
+    # Bind an ephemeral port so a running Jarvis instance cannot collide with
+    # the smoke test on the configured admin API port.
+    await srv.start(port=0)
     try:
         assert getattr(srv, "running", True), "WebServer.running should be True"
     finally:
@@ -61,7 +63,7 @@ def test_rest_api_health(test_config):
     srv = WebServer(test_config)
     app = getattr(srv, "app", None)
     if app is None:
-        pytest.skip("WebServer.app Attribut fehlt")
+        pytest.skip("WebServer.app attribute is missing")
     with TestClient(app) as client:
         r = client.get("/api/health")
         assert r.status_code == 200
@@ -75,7 +77,7 @@ def test_rest_api_plugins(test_config):
     srv = WebServer(test_config)
     app = getattr(srv, "app", None)
     if app is None:
-        pytest.skip("WebServer.app Attribut fehlt")
+        pytest.skip("WebServer.app attribute is missing")
     with TestClient(app) as client:
         r = client.get("/api/plugins")
         assert r.status_code == 200
@@ -91,7 +93,7 @@ def test_websocket_event_echo(test_config):
     srv = WebServer(test_config)
     app = getattr(srv, "app", None)
     if app is None:
-        pytest.skip("WebServer.app Attribut fehlt")
+        pytest.skip("WebServer.app attribute is missing")
     with TestClient(app) as client:
         try:
             ws_ctx = client.websocket_connect("/ws")
@@ -101,7 +103,7 @@ def test_websocket_event_echo(test_config):
             welcome = ws.receive_json()
             assert welcome.get("type") == "welcome"
 
-            # Feuere ein Event via REST-Debug-Endpoint
+            # Emit an event through the REST debug endpoint.
             r = client.post("/api/debug/emit-test-event")
             if r.status_code == 404:
                 pytest.skip("debug endpoint /api/debug/emit-test-event not implemented")

--- a/tests/integration/test_tasks_recurring.py
+++ b/tests/integration/test_tasks_recurring.py
@@ -95,7 +95,12 @@ class _FakeRunner:
     def __init__(self) -> None:
         self.dispatched: list[str] = []
 
-    async def run(self, task_id: str, **_kwargs: object) -> None:
+    async def run(
+        self,
+        task_id: str,
+        _token: object | None = None,
+        **_kwargs: object,
+    ) -> None:
         self.dispatched.append(task_id)
 
 

--- a/tests/integration/test_voice_mission_e2e_chatgpt.py
+++ b/tests/integration/test_voice_mission_e2e_chatgpt.py
@@ -1,4 +1,4 @@
-"""Live end-to-end integration test for the Welle-6 ChatGPT worker/critic.
+"""Live end-to-end integration test for the Wave-6 ChatGPT worker/critic.
 
 This test drives a real Personal Jarvis mission through the entire
 Phase-6 stack -- ``bootstrap_missions`` boots the MissionManager,
@@ -76,6 +76,7 @@ def _codex_logged_in() -> bool:
 
 pytestmark = [
     pytest.mark.integration,
+    pytest.mark.slow,
     pytest.mark.skipif(
         not _codex_logged_in(),
         reason="requires Codex ChatGPT OAuth",
@@ -83,8 +84,8 @@ pytestmark = [
 ]
 
 
-_PROOF_FILENAME = "welle6_e2e_proof.md"
-_PROOF_CONTENT = "Welle 6 voice mission OK"
+_PROOF_FILENAME = "wave6_e2e_proof.md"
+_PROOF_CONTENT = "Wave 6 voice mission OK"
 _MISSION_PROMPT = (
     f"Create a file {_PROOF_FILENAME} with EXACTLY this single line: "
     f"{_PROOF_CONTENT}"
@@ -133,7 +134,6 @@ def short_root(request: pytest.FixtureRequest) -> Path:
     ``prune_and_sweep_leaked`` helper sweeps stale leaked dirs older
     than 6h on the next mission bootstrap anyway.
     """
-    import shutil as _shutil
     import uuid as _uuid
 
     base = Path("C:/tmp/p-jarvis-e2e") / _uuid.uuid4().hex[:8]
@@ -265,13 +265,13 @@ async def test_chatgpt_mission_writes_proof_file_and_reaches_approved(
         else:
             # Secondary path: extract from the captured diff.patch.
             # A `git diff` "new file" hunk for our proof file looks like:
-            #   diff --git a/welle6_e2e_proof.md b/welle6_e2e_proof.md
+            #   diff --git a/wave6_e2e_proof.md b/wave6_e2e_proof.md
             #   new file mode 100644
             #   index ...
             #   --- /dev/null
-            #   +++ b/welle6_e2e_proof.md
+            #   +++ b/wave6_e2e_proof.md
             #   @@ -0,0 +1 @@
-            #   +Welle 6 voice mission OK
+            #   +Wave 6 voice mission OK
             # We pluck the added lines (those starting with "+" but not
             # "+++") for the target file and verify exact match.
             diffs = list(mission_dir.rglob("diff.patch")) + list(

--- a/tests/missions/critic/test_runner_claude_direct.py
+++ b/tests/missions/critic/test_runner_claude_direct.py
@@ -47,6 +47,18 @@ def _claude_cli_viable_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda: True,
     )
 
+    # A WebServer or CLI-registry test may seed the process-wide capability
+    # singleton before this module runs. Start every critic-path test with a
+    # fresh registry so unrelated tool capabilities cannot change its verdict.
+    import jarvis.core.capabilities as capability_module
+
+    previous_registry = capability_module._registry_instance
+    capability_module._registry_instance = None
+    try:
+        yield
+    finally:
+        capability_module._registry_instance = previous_registry
+
 
 def _valid_verdict_json(verdict: str = "approve") -> str:
     """A schema-valid CriticVerdict as the raw text claude --print prints.
@@ -64,7 +76,9 @@ def _valid_verdict_json(verdict: str = "approve") -> str:
         "issues": [],
         "correction_instruction": "" if verdict == "approve" else "fix x",
         "summary": "ok" if verdict == "approve" else "needs fix",
-        "summary_de": "ok" if verdict == "approve" else "muss korrigiert werden",  # i18n-allow (German value under summary_de field)
+        "summary_de": (
+            "ok" if verdict == "approve" else "muss korrigiert werden"  # i18n-allow
+        ),
         "confidence": 0.9,
         "suggested_next_action": "accept" if verdict == "approve" else "retry",
     })

--- a/tests/review/test_config_review_section.py
+++ b/tests/review/test_config_review_section.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from jarvis.core.config import ReviewConfig, ReviewRubricConfig
+from jarvis.core.config import JarvisConfig, ReviewConfig, ReviewRubricConfig
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -81,16 +81,13 @@ def test_rubric_items_not_empty() -> None:
 # ----------------------------------------------------------------------
 
 
-def test_jarvis_toml_review_section_exists_and_validates() -> None:
-    """End-to-end: the real jarvis.toml must have a [review] section
-    that ReviewConfig.model_validate accepts."""
-    jarvis_toml = REPO_ROOT / "jarvis.toml"
+def test_example_config_uses_valid_review_defaults() -> None:
+    """The public example remains valid when the review section is omitted."""
+    jarvis_toml = REPO_ROOT / "jarvis.toml.example"
     assert jarvis_toml.exists()
 
     raw = tomllib.loads(jarvis_toml.read_text(encoding="utf-8"))
-    assert "review" in raw, "jarvis.toml has no [review] section"
-
-    cfg = ReviewConfig.model_validate(raw["review"])
+    cfg = JarvisConfig.model_validate(raw).review
     # Values from Plan §6.4
     assert cfg.enabled is True
     assert cfg.max_iterations == 3

--- a/tests/unit/admin/test_executor_winget.py
+++ b/tests/unit/admin/test_executor_winget.py
@@ -8,6 +8,7 @@ Important:
 from __future__ import annotations
 
 import asyncio
+import sys
 
 import pytest
 
@@ -17,6 +18,7 @@ from jarvis.admin.schema import (
     ReadRegistryOp,
     StartServiceOp,
     UninstallWingetOp,
+    WriteRegistryHkcuOp,
 )
 
 
@@ -152,5 +154,22 @@ async def test_read_registry_hkcu_environment_smoke(monkeypatch):
     assert resp.success in (True, False)
     if not resp.success:
         assert resp.error_code in (
-            "registry_key_not_found", "registry_read_failed",
+            "registry_key_not_found",
+            "registry_read_failed",
+            "registry_unsupported",
         )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="non-Windows degradation path")
+@pytest.mark.asyncio
+async def test_write_registry_degrades_honestly_off_windows():
+    resp = await AdminExecutor().execute(
+        WriteRegistryHkcuOp(
+            key_path=r"Software\PersonalJarvisTest",
+            value_name="Sample",
+            value_data="value",
+        )
+    )
+    assert resp.success is False
+    assert resp.error_code == "registry_unsupported"
+    assert resp.error_message == "Windows Registry is unavailable on this platform."

--- a/tests/unit/admin/test_transport_seam.py
+++ b/tests/unit/admin/test_transport_seam.py
@@ -75,7 +75,9 @@ async def test_signed_envelope_roundtrips_through_fake_transport():
         assert resp.op_id == op.op_id
         if not resp.success:
             assert resp.error_code in (
-                "registry_key_not_found", "registry_read_failed",
+                "registry_key_not_found",
+                "registry_read_failed",
+                "registry_unsupported",
             )
         # The fake actually carried the raw signed envelope.
         assert transport.roundtrips, "transport.roundtrip was never invoked"

--- a/tests/unit/brain/conftest.py
+++ b/tests/unit/brain/conftest.py
@@ -18,6 +18,7 @@ def _isolate_capability_registry():
     reg = get_registry()
     with reg._lock:  # noqa: SLF001 — test-only snapshot of the singleton
         snapshot = dict(reg._caps)  # noqa: SLF001
+        reg._caps.clear()  # noqa: SLF001
     try:
         yield
     finally:

--- a/tests/unit/brain/test_cu_model_selection.py
+++ b/tests/unit/brain/test_cu_model_selection.py
@@ -9,9 +9,8 @@ from __future__ import annotations
 
 from jarvis.brain.manager import BrainManager, get_tier_default_model
 from jarvis.core.bus import EventBus
-from jarvis.core.config import BrainProviderConfig, load_config
+from jarvis.core.config import BrainProviderConfig, BrainTierConfig, load_config
 from jarvis.harness import screenshot_only_loop as sol
-
 
 # --- config field -----------------------------------------------------------
 
@@ -42,31 +41,33 @@ def test_brain_provider_config_voice_defaults_empty():
 
 def test_cu_model_prefers_pinned_cu_model():
     cfg = load_config()
-    cfg.brain.router.provider = "gemini"
-    cfg.brain.providers["gemini"].model = "gemini-3.5-flash"
-    cfg.brain.providers["gemini"].cu_model = "gemini-3.1-pro-preview"
+    cfg.brain.router = BrainTierConfig(provider="gemini")
+    cfg.brain.providers["gemini"] = BrainProviderConfig(
+        model="gemini-3.5-flash",
+        cu_model="gemini-3.1-pro-preview",
+    )
     mgr = BrainManager.from_tier_config("router", cfg, EventBus())
     assert mgr._cu_model("gemini") == "gemini-3.1-pro-preview"
 
 
 def test_cu_model_falls_back_to_main_model_when_unset():
     cfg = load_config()
-    cfg.brain.router.provider = "gemini"
-    cfg.brain.providers["gemini"].model = "gemini-3.5-flash"
-    cfg.brain.providers["gemini"].cu_model = None
+    cfg.brain.router = BrainTierConfig(provider="gemini")
+    cfg.brain.providers["gemini"] = BrainProviderConfig(
+        model="gemini-3.5-flash",
+        cu_model=None,
+    )
     mgr = BrainManager.from_tier_config("router", cfg, EventBus())
     assert mgr._cu_model("gemini") == "gemini-3.5-flash"
 
 
 def test_cu_model_falls_back_to_router_default_for_absent_provider():
     cfg = load_config()
-    cfg.brain.router.provider = "gemini"
+    cfg.brain.router = BrainTierConfig(provider="gemini")
     mgr = BrainManager.from_tier_config("router", cfg, EventBus())
     # A provider with no [brain.providers.<p>] block resolves to the router default.
-    assert mgr._cu_model("openrouter") == (
-        cfg.brain.providers.get("openrouter").cu_model
-        or cfg.brain.providers.get("openrouter").model
-        or get_tier_default_model("router", "openrouter")
+    assert mgr._cu_model("openrouter") == get_tier_default_model(
+        "router", "openrouter"
     )
 
 

--- a/tests/unit/brain/test_deep_brain_follows_active.py
+++ b/tests/unit/brain/test_deep_brain_follows_active.py
@@ -16,22 +16,33 @@ import pytest
 
 from jarvis.brain.manager import BrainManager
 from jarvis.core.bus import EventBus
-from jarvis.core.config import load_config
+from jarvis.core.config import BrainTierConfig, load_config
+
+
+@pytest.fixture(autouse=True)
+def _all_test_providers_have_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep chain-order tests independent of the host's private key store."""
+    monkeypatch.setattr(
+        "jarvis.core.config.get_secret_any",
+        lambda _candidates: "test-key",
+    )
 
 
 def _cfg(*, primary: str, provider: str, fallback_provider: str | None):
     cfg = load_config()
     cfg.brain.primary = primary
-    cfg.brain.router.provider = provider
-    cfg.brain.router.fallback_provider = fallback_provider
+    cfg.brain.router = BrainTierConfig(
+        provider=provider,
+        fallback_provider=fallback_provider,
+    )
     return cfg
 
 
 def test_deep_brain_follows_override_when_no_explicit_split() -> None:
     # primary=claude-api overrides the tier default gemini; fallback==provider
     # means there is NO deliberate cross-provider deep split → deep must follow
-    # claude-api. (claude-api is used because the chain builder drops providers
-    # without a configured key; claude-api is keyed in this environment.)
+    # claude-api. The fixture supplies synthetic credentials so this assertion
+    # never depends on a maintainer machine's private key store.
     cfg = _cfg(primary="claude-api", provider="gemini", fallback_provider="gemini")
     mgr = BrainManager.from_tier_config("router", cfg, EventBus(), provider_override="claude-api")
 

--- a/tests/unit/brain/test_key_set_auto_activates_brain.py
+++ b/tests/unit/brain/test_key_set_auto_activates_brain.py
@@ -19,15 +19,17 @@ import pytest
 
 from jarvis.brain.manager import BrainManager
 from jarvis.core.bus import EventBus
-from jarvis.core.config import load_config
+from jarvis.core.config import BrainTierConfig, load_config
 from jarvis.core.events import SecretConfigured
 
 
 def _cfg(*, primary: str):
     cfg = load_config()
     cfg.brain.primary = primary
-    cfg.brain.router.provider = primary
-    cfg.brain.router.fallback_provider = primary
+    cfg.brain.router = BrainTierConfig(
+        provider=primary,
+        fallback_provider=primary,
+    )
     return cfg
 
 

--- a/tests/unit/brain/test_tier_model_resolution.py
+++ b/tests/unit/brain/test_tier_model_resolution.py
@@ -14,7 +14,11 @@ import pytest
 
 from jarvis.brain.manager import BrainManager
 from jarvis.core.bus import EventBus
-from jarvis.core.config import BrainTierConfig, JarvisConfig, load_config
+from jarvis.core.config import (
+    BrainProviderConfig,
+    BrainTierConfig,
+    JarvisConfig,
+)
 
 # One representative non-default frontier model per configured brain provider.
 # Gemini is only one row — model selection must resolve for EVERY provider.
@@ -26,8 +30,24 @@ PROVIDER_FAST_DEEP_CASES = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def _all_test_providers_have_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep model-chain assertions independent of the host's key store."""
+    monkeypatch.setattr(
+        "jarvis.core.config.get_secret_any",
+        lambda _candidates: "test-key",
+    )
+
+
+def _config(provider: str = "gemini") -> JarvisConfig:
+    cfg = JarvisConfig()
+    cfg.brain.router = BrainTierConfig(provider=provider)
+    cfg.brain.providers[provider] = BrainProviderConfig()
+    return cfg
+
+
 def test_router_keeps_fast_model_when_fallback_is_same_provider() -> None:
-    cfg = load_config()
+    cfg = _config()
     # Real-world shape: gemini FAST primary + gemini PRO fallback (same provider).
     cfg.brain.router.provider = "gemini"
     cfg.brain.router.model = "gemini-3.5-flash"
@@ -40,10 +60,21 @@ def test_router_keeps_fast_model_when_fallback_is_same_provider() -> None:
     assert mgr._fast_model("gemini") == "gemini-3.5-flash"
 
 
+def test_provider_model_drives_router_when_tier_model_is_omitted() -> None:
+    """A fresh install keeps the model selected through the provider UI."""
+    cfg = _config()
+    cfg.brain.router.model = None
+    cfg.brain.providers["gemini"].model = "gemini-3.5-flash-ui-choice"
+
+    mgr = BrainManager.from_tier_config("router", cfg, EventBus())
+
+    assert mgr._fast_model("gemini") == "gemini-3.5-flash-ui-choice"
+
+
 def test_router_fallback_chain_still_offers_pro_as_failover() -> None:
     # Fixing the clobber must NOT drop the pro failover from the chain — flash
     # is primary, pro remains the gemini-tier failover.
-    cfg = load_config()
+    cfg = _config()
     cfg.brain.router.provider = "gemini"
     cfg.brain.router.model = "gemini-3.5-flash"
     cfg.brain.router.fallback_provider = "gemini"
@@ -60,7 +91,7 @@ def test_router_caps_thinking_budget_without_touching_global_config() -> None:
     # The router (dispatcher) must not "think" for seconds. The cap lives on the
     # deep-copied router config only — the global config (used by workers/critic)
     # keeps its full-reasoning default.
-    cfg = load_config()
+    cfg = _config()
     cfg.brain.router.provider = "gemini"
     cfg.brain.router.model = "gemini-3.5-flash"
 
@@ -106,7 +137,7 @@ def test_user_selected_deep_model_drives_the_deep_chain() -> None:
     the deep-tier model is steered by [brain.providers.<p>].deep_model, and the
     router-config build must NOT clobber that selection.
     """
-    cfg = load_config()
+    cfg = _config()
     cfg.brain.router.provider = "gemini"
     cfg.brain.router.model = "gemini-3.5-flash"
     # The user explicitly picks a non-default deep model for Gemini.
@@ -130,7 +161,7 @@ def test_user_selected_fast_model_resolves_for_every_provider(
     for EVERY brain provider when that provider is the active router brain. The
     fast/router model is steered by [brain.router].model and must survive the
     same-provider-fallback clobber for all of them."""
-    cfg = load_config()
+    cfg = _config(provider)
     cfg.brain.router.provider = provider
     cfg.brain.router.model = fast_pick
     cfg.brain.router.fallback_provider = provider
@@ -150,7 +181,7 @@ def test_user_selected_deep_model_resolves_for_every_provider(
     whatever model the user picks per provider is the one a deep turn runs on
     (and thus the one published on the brain turn and shown in the transcript).
     The router-config build must not clobber deep_model for any provider."""
-    cfg = load_config()
+    cfg = _config(provider)
     cfg.brain.providers[provider].deep_model = deep_pick
 
     mgr = BrainManager.from_tier_config("router", cfg, EventBus())

--- a/tests/unit/channels/test_discord_channel.py
+++ b/tests/unit/channels/test_discord_channel.py
@@ -171,7 +171,11 @@ def test_is_allowed_require_mention_passes_with_mention() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_pair_first_dm_claims_empty_allowlist() -> None:
+def test_pair_first_dm_claims_empty_allowlist(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_CONFIG", str(tmp_path / "jarvis.toml"))
     cfg = DiscordConfig(enabled=True, allowed_user_ids=[], pair_on_first_dm=True)
     ch = _make_channel(cfg)
     assert ch._pair_first_dm(_make_message(user_id=777)) is True  # noqa: SLF001

--- a/tests/unit/google_cli/test_pty_runner.py
+++ b/tests/unit/google_cli/test_pty_runner.py
@@ -9,10 +9,6 @@ No real CLI, PTY, or network is touched — the backend is faked.
 """
 from __future__ import annotations
 
-import pytest
-
-import os
-
 from jarvis.google_cli.pty_runner import (
     PtyRunResult,
     extract_cli_answer,
@@ -115,7 +111,7 @@ def test_extract_strips_trailing_lone_spinner_glyph():
 
 # ---- repair_agy_path ------------------------------------------------------
 # agy spawns cmd.exe + npm internally (MCP servers); in a degraded environment
-# (PATH stripped of System32 / Node) that fails with "chcp nicht erkannt". The  # i18n-allow
+# (PATH stripped of System32 / Node) that fails with "chcp not recognized". The
 # child PATH must carry the standard Windows system dirs.
 
 
@@ -125,14 +121,14 @@ def test_repair_path_adds_system32_when_missing():
         is_windows=True,
         system_root=r"C:\Windows",
     )
-    parts = [p.lower() for p in out.split(os.pathsep)]
+    parts = [p.lower() for p in out.split(";")]
     assert r"c:\windows\system32" in parts
     assert r"c:\windows\system32\wbem" in parts
     assert r"c:\some\other" in parts.__str__() or r"c:\some\other" in parts
 
 
 def test_repair_path_idempotent_when_present():
-    existing = os.pathsep.join([r"C:\Windows\System32", r"C:\Windows\System32\Wbem", r"C:\Windows"])
+    existing = ";".join([r"C:\Windows\System32", r"C:\Windows\System32\Wbem", r"C:\Windows"])
     out = repair_agy_path(existing, is_windows=True, system_root=r"C:\Windows")
     # No duplicate System32 entries.
     assert out.lower().count(r"c:\windows\system32".lower()) == existing.lower().count(
@@ -144,7 +140,7 @@ def test_repair_path_includes_node_dir_when_given():
     out = repair_agy_path(
         "", is_windows=True, system_root=r"C:\Windows", node_dir=r"C:\Program Files\nodejs"
     )
-    assert r"c:\program files\nodejs" in [p.lower() for p in out.split(os.pathsep)]
+    assert r"c:\program files\nodejs" in [p.lower() for p in out.split(";")]
 
 
 def test_repair_path_noop_on_posix():
@@ -227,11 +223,11 @@ def test_run_passes_env_and_cwd_to_backend():
     run_cli_over_pty(
         ("agy", "--print", "x"),
         timeout_s=5.0,
-        cwd="/tmp/work",
+        cwd="/work",
         env={"PATH": "/safe"},
         backend=backend,
     )
-    assert backend.spawn_kwargs["cwd"] == "/tmp/work"
+    assert backend.spawn_kwargs["cwd"] == "/work"
     assert backend.spawn_kwargs["env"] == {"PATH": "/safe"}
 
 

--- a/tests/unit/harness/test_cu_loop_robustness.py
+++ b/tests/unit/harness/test_cu_loop_robustness.py
@@ -253,6 +253,13 @@ def _isolate_host(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     # Keep the UI-tree-source singleton hermetic between tests.
     monkeypatch.setattr(loop_mod, "_UI_TREE_SOURCE", None, raising=False)
+    # Never inspect or focus a real window named in a test prompt. Dedicated
+    # target-focus tests provide their own fake window inventory.
+    monkeypatch.setattr(
+        loop_mod,
+        "_focus_task_target_window",
+        lambda _ctx, _prompt: None,
+    )
     # Neutralize the post-open_app settle probe suite-wide (it sleeps up to
     # 1 s per launch on empty fake titles). The dedicated settle tests
     # re-enable it with their own explicit timeout/poll values.

--- a/tests/unit/memory/wiki/test_curator_llm.py
+++ b/tests/unit/memory/wiki/test_curator_llm.py
@@ -765,6 +765,10 @@ async def test_propose_updates_uses_default_registry_if_none_injected(
         "instantiate",
         _fake_instantiate,
     )
+    monkeypatch.setattr(
+        "jarvis.memory.wiki.provider_chain.credential_ready_wiki_providers",
+        lambda *, available, **_kwargs: set(available),
+    )
 
     llm = WikiCuratorLLM(
         config=cfg,

--- a/tests/unit/platform/test_probes.py
+++ b/tests/unit/platform/test_probes.py
@@ -109,8 +109,10 @@ def test_ax_permission_windows_always_true(monkeypatch):
 
 
 def test_ax_permission_macos_unknown_without_pyobjc(monkeypatch):
+    import sys
+
     _force_platform(monkeypatch, "darwin")
-    # ApplicationServices import will fail on a non-mac box → None (unknown).
+    monkeypatch.setitem(sys.modules, "ApplicationServices", None)
     assert probes.ax_permission_granted() is None
 
 

--- a/tests/unit/plugins/tool/test_app_resolver.py
+++ b/tests/unit/plugins/tool/test_app_resolver.py
@@ -28,7 +28,11 @@ def test_spotify_aliases_resolve_to_protocol_startfile_target(name: str) -> None
 
 
 @pytest.mark.parametrize("name", ["terminal", "windows terminal", "windowsterminal"])
-def test_windows_terminal_aliases_resolve_to_wt_executable(name: str) -> None:
+def test_windows_terminal_aliases_resolve_to_wt_executable(
+    name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(app_resolver, "detect_platform", lambda: "win32")
     assert resolve_app_launch_target(name) == LaunchTarget("executable", "wt")
 
 
@@ -57,7 +61,11 @@ def test_microsoft_store_is_in_the_windows_app_whitelist() -> None:
 
 
 @pytest.mark.parametrize("name", ["powershell", "pwsh", "cmd"])
-def test_shell_names_remain_direct_executable_targets(name: str) -> None:
+def test_shell_names_remain_direct_executable_targets(
+    name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(app_resolver, "detect_platform", lambda: "win32")
     assert resolve_app_launch_target(name) == LaunchTarget("executable", name)
 
 
@@ -69,6 +77,7 @@ def test_app_paths_hit_resolves_to_absolute_executable(
     Regression for the silent-no-op bug: ``os.startfile("chrome")`` did nothing
     (Chrome is not on PATH), so the launch had to be pinned to a real path.
     """
+    monkeypatch.setattr(app_resolver, "detect_platform", lambda: "win32")
     fake = r"C:\Program Files\Google\Chrome\Application\chrome.exe"
     monkeypatch.setattr(
         app_resolver, "_resolve_via_app_paths", lambda exe: fake if exe == "chrome.exe" else None
@@ -80,6 +89,7 @@ def test_exe_alias_maps_voice_name_to_real_executable_basename(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """'edge'/'word' must be looked up under their real exe names."""
+    monkeypatch.setattr(app_resolver, "detect_platform", lambda: "win32")
     queried: list[str] = []
 
     def _spy(exe: str) -> str | None:
@@ -97,6 +107,7 @@ def test_path_resolution_when_not_in_app_paths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Built-ins like notepad/calc resolve via PATH to an absolute exe."""
+    monkeypatch.setattr(app_resolver, "detect_platform", lambda: "win32")
     monkeypatch.setattr(app_resolver, "_resolve_via_app_paths", lambda exe: None)
     monkeypatch.setattr(
         app_resolver.shutil,
@@ -112,6 +123,7 @@ def test_falls_back_to_startfile_when_unresolvable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Truly unknown names degrade to the shell (last-resort startfile)."""
+    monkeypatch.setattr(app_resolver, "detect_platform", lambda: "win32")
     monkeypatch.setattr(app_resolver, "_resolve_via_app_paths", lambda exe: None)
     monkeypatch.setattr(app_resolver.shutil, "which", lambda name: None)
     assert resolve_app_launch_target("frobnicator") == LaunchTarget("startfile", "frobnicator")
@@ -229,6 +241,7 @@ async def test_open_app_uses_resolved_executable_target_before_launch(
 ) -> None:
     popen_calls: list[list[str]] = []
 
+    monkeypatch.setattr(app_resolver, "detect_platform", lambda: "win32")
     monkeypatch.delattr(os, "startfile", raising=False)
     monkeypatch.setattr(subprocess, "Popen", lambda args, **kwargs: popen_calls.append(args))
 

--- a/tests/unit/plugins/tool/test_open_app_plausibility.py
+++ b/tests/unit/plugins/tool/test_open_app_plausibility.py
@@ -82,7 +82,8 @@ async def test_execute_hallucination_still_flagged_as_misheard(monkeypatch):
     assert "Misshearing" in (res.error or "")
 
 
-def test_whitelisted_app_still_plausible():
+def test_whitelisted_app_still_plausible(monkeypatch):
+    monkeypatch.setattr(oa, "KNOWN_APPS", oa._KNOWN_APPS_WIN)
     ok, _reason, kind = _is_plausible_app_name("notepad")
     assert ok is True
     assert kind == ""

--- a/tests/unit/plugins/tool/test_open_app_reuse.py
+++ b/tests/unit/plugins/tool/test_open_app_reuse.py
@@ -68,6 +68,7 @@ async def test_launches_when_not_running(monkeypatch):
 
 async def test_multi_instance_app_always_launches(monkeypatch):
     calls = _stub_launch(monkeypatch)
+    monkeypatch.setattr(oa, "KNOWN_APPS", oa._KNOWN_APPS_WIN)
     monkeypatch.setattr(oa.window_state, "is_app_running", lambda n: WindowInfo("File Explorer"))
     raised: list = []
     monkeypatch.setattr(

--- a/tests/unit/skills/test_skill_authoring.py
+++ b/tests/unit/skills/test_skill_authoring.py
@@ -2,7 +2,7 @@
 
 Plan acceptance criteria §7.5:
 - Spawn produces a valid SKILL.md in draft state
-- state=draft is forced even when Sub-Jarvis wrongly writes `active`
+- state=draft is forced even when a Jarvis-Agent wrongly writes `active`
 - Validation retry works with concrete Pydantic feedback
 - Name clash produces a suffix, no overwrite
 - Draft skill doesn't trigger (negative test with TriggerMatcher)
@@ -66,7 +66,7 @@ def _good_response_json(**overrides) -> str:
 
 
 # ----------------------------------------------------------------------
-# SkillDraft Schema (Plan-§AD-9 + Slug-Hardening)
+# SkillDraft schema (Plan-§AD-9 + slug hardening)
 # ----------------------------------------------------------------------
 
 
@@ -111,7 +111,7 @@ class TestSkillDraftSchema:
 
 
 # ----------------------------------------------------------------------
-# write_draft — state=draft Forcierung (Plan-§AD-8)
+# write_draft — state=draft enforcement (Plan-§AD-8)
 # ----------------------------------------------------------------------
 
 
@@ -132,7 +132,7 @@ class TestWriteDraft:
     def test_state_active_in_draft_is_forced_to_draft(
         self, user_skills_root: Path
     ) -> None:
-        """Plan-§AD-8: Sub-Jarvis output state="active" is unconditionally
+        """Plan-§AD-8: Jarvis-Agent output state="active" is unconditionally
         overwritten to "draft" when writing.
         """
         draft = _draft(state="active")
@@ -179,7 +179,7 @@ class TestPathTraversalDefense:
 
 
 # ----------------------------------------------------------------------
-# safe_lint_skill_body (Plan-§7.5 Sicherheits-Lint)
+# safe_lint_skill_body (Plan-§7.5 security lint)
 # ----------------------------------------------------------------------
 
 
@@ -274,7 +274,7 @@ class TestSafeLint:
 
 
 # ----------------------------------------------------------------------
-# SkillAuthoringRunner — Sub-Jarvis-Mock + Validation-Loop
+# SkillAuthoringRunner — Jarvis-Agent mock + validation loop
 # ----------------------------------------------------------------------
 
 
@@ -320,10 +320,10 @@ class TestRunnerHappyPath:
 
 
 class TestRunnerForcedStateOverride:
-    def test_subjarvis_active_yields_forced_override_audit(
+    def test_jarvis_agent_active_yields_forced_override_audit(
         self, user_skills_root: Path, audit: SelfModAudit
     ) -> None:
-        """Plan-AC §7.5: state=draft is forced even when Sub-Jarvis returns 'active'."""
+        """Plan-AC §7.5: state=draft is forced when a Jarvis-Agent returns 'active'."""
         async def fake_spawn(prompt: str) -> str:
             return _good_response_json(state="active")
 

--- a/tests/unit/speech/test_pipeline_lightweight_wake.py
+++ b/tests/unit/speech/test_pipeline_lightweight_wake.py
@@ -38,6 +38,12 @@ def _cfg_groq() -> SimpleNamespace:
     return SimpleNamespace(stt=STTConfig(provider="groq-api"))
 
 
+@pytest.fixture(autouse=True)
+def _configured_groq_credential(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep provider selection independent of credentials on the test host."""
+    monkeypatch.setenv("GROQ_API_KEY", "test-groq-key")
+
+
 def test_lightweight_mode_instantiates_no_faster_whisper() -> None:
     pipe = SpeechPipeline(
         tts=FakeTTS(),

--- a/tests/unit/test_router_vision_config.py
+++ b/tests/unit/test_router_vision_config.py
@@ -7,16 +7,18 @@ configs without the section must still load cleanly.
 from __future__ import annotations
 
 import tomllib
+from pathlib import Path
 
 from jarvis.core.config import (
-    DEFAULT_CONFIG_FILE,
+    JarvisConfig,
     RouterVisionConfig,
-    load_config,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_router_vision_config_defaults():
-    """RouterVisionConfig liefert ohne jegliche TOML-Daten die dokumentierten Defaults."""
+    """RouterVisionConfig provides documented defaults without TOML data."""
     cfg = RouterVisionConfig()
     assert cfg.enabled is False  # latency fix: opt-in only (default changed)
     assert cfg.refresh_interval_s == 2.0
@@ -24,50 +26,44 @@ def test_router_vision_config_defaults():
     assert cfg.capture_mode == "screenshot"
     assert cfg.max_image_kb == 500
     assert cfg.pause_on_idle is True
-    # Voice-Phrasen DE+EN — Privacy-Mode + Resume.
+    # German and English runtime phrases for privacy mode and resume.
     assert cfg.voice_pause_phrase_de == "privacy"
     assert cfg.voice_pause_phrase_en == "privacy mode"
     assert cfg.voice_resume_phrase_de == "du darfst wieder sehen"
     assert cfg.voice_resume_phrase_en == "vision back on"
-    # Sanity: enthaelt die Plan-Schluesselbegriffe.
+    # Sanity check for the defining intent words.
     assert "privacy" in cfg.voice_pause_phrase_de
     assert "vision" in cfg.voice_resume_phrase_en
 
 
-def test_router_vision_config_loaded_from_jarvis_toml():
-    """Loads the global jarvis.toml via tomllib AND via load_config() and
-    checks that `[brain.router.vision]` correctly lands in RouterVisionConfig.
+def test_public_example_loads_without_router_vision_override():
+    """The public example loads without requiring a private jarvis.toml."""
+    toml_path = REPO_ROOT / "jarvis.toml.example"
+    assert toml_path.exists(), f"public config example not found at {toml_path}"
 
-    Two-layer test:
-      1. Raw TOML — guarantees the section exists with the expected keys.
-      2. load_config() — guarantees Pydantic auto-unmarshals the section
-         into `cfg.brain.router.vision` (RouterVisionConfig).
-    """
-    toml_path = DEFAULT_CONFIG_FILE
-    assert toml_path.exists(), f"jarvis.toml not found at {toml_path}"
-
-    # 1. Raw-TOML layer — section exists with the plan values.
     with toml_path.open("rb") as f:
         data = tomllib.load(f)
-    vsec = data["brain"]["router"]["vision"]
-    assert vsec["enabled"] is False  # latency fix: opt-in only (default changed)
-    assert vsec["capture_mode"] == "screenshot"
-    assert vsec["refresh_interval_s"] == 2.0
-    assert vsec["max_staleness_s"] == 2.0
-    assert vsec["max_image_kb"] == 500
-    assert vsec["pause_on_idle"] is True
-    assert vsec["voice_pause_phrase_de"] == "privacy"
-    assert vsec["voice_pause_phrase_en"] == "privacy mode"
-    assert vsec["voice_resume_phrase_de"] == "du darfst wieder sehen"
-    assert vsec["voice_resume_phrase_en"] == "vision back on"
+    cfg = JarvisConfig.model_validate(data)
+    assert cfg.brain.router is None
 
-    # 2. load_config()-Layer — Pydantic-Auto-Unmarshal landet im richtigen Feld.
-    cfg = load_config(toml_path)
-    assert cfg.brain.router is not None, "brain.router-Section fehlt in jarvis.toml"
-    vision = cfg.brain.router.vision
-    assert isinstance(vision, RouterVisionConfig)
-    assert vision.enabled is False  # latency fix: opt-in only (default changed)
-    assert vision.capture_mode == "screenshot"
-    assert vision.refresh_interval_s == 2.0
-    assert vision.voice_pause_phrase_de == "privacy"
-    assert vision.voice_resume_phrase_en == "vision back on"
+
+def test_router_vision_section_is_unmarshalled_into_typed_config():
+    """An explicit nested section lands in RouterVisionConfig."""
+    cfg = JarvisConfig.model_validate(
+        {
+            "brain": {
+                "router": {
+                    "provider": "gemini",
+                    "vision": {
+                        "enabled": True,
+                        "refresh_interval_s": 3.5,
+                        "capture_mode": "screenshot",
+                    }
+                }
+            }
+        }
+    )
+
+    assert isinstance(cfg.brain.router.vision, RouterVisionConfig)
+    assert cfg.brain.router.vision.enabled is True
+    assert cfg.brain.router.vision.refresh_interval_s == 3.5

--- a/tests/unit/ui/test_relauncher.py
+++ b/tests/unit/ui/test_relauncher.py
@@ -90,7 +90,8 @@ def test_wait_times_out_when_pid_never_dies():
     assert out is False
 
 
-def test_main_waits_then_spawns_fresh_launcher():
+def test_main_waits_then_spawns_fresh_launcher(monkeypatch):
+    monkeypatch.setattr(relauncher.sys, "platform", "linux")
     spawned: list[dict] = []
 
     def fake_spawn(cmd, **kwargs):

--- a/tests/unit/vision/test_region_capture.py
+++ b/tests/unit/vision/test_region_capture.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from jarvis.vision import screenshot as screenshot_module
 from jarvis.vision.screenshot import capture_region, region_bbox_around
 
 
@@ -25,7 +26,7 @@ def test_region_bbox_clamps_to_virtual_bounds() -> None:
     assert bb["width"] >= 1 and bb["height"] >= 1
 
 
-def test_capture_region_returns_jpeg_bytes() -> None:
+def test_capture_region_returns_jpeg_bytes(monkeypatch) -> None:
     import pytest
 
     pytest.importorskip("PIL")  # Pillow lives in the [desktop] extra (cloud-first)
@@ -34,6 +35,9 @@ def test_capture_region_returns_jpeg_bytes() -> None:
         w, h = bbox["width"], bbox["height"]
         return ((w, h), b"\x10\x20\x30" * (w * h))  # solid RGB fill
 
+    monkeypatch.setattr(
+        screenshot_module, "warn_if_screen_recording_denied", lambda: False
+    )
     data = capture_region(
         {"left": 0, "top": 0, "width": 8, "height": 8}, grab=fake_grab
     )
@@ -41,7 +45,7 @@ def test_capture_region_returns_jpeg_bytes() -> None:
     assert len(data) > 10
 
 
-def test_capture_region_png_format() -> None:
+def test_capture_region_png_format(monkeypatch) -> None:
     import pytest
 
     pytest.importorskip("PIL")
@@ -50,6 +54,9 @@ def test_capture_region_png_format() -> None:
         w, h = bbox["width"], bbox["height"]
         return ((w, h), b"\xaa\xbb\xcc" * (w * h))
 
+    monkeypatch.setattr(
+        screenshot_module, "warn_if_screen_recording_denied", lambda: False
+    )
     data = capture_region(
         {"left": 0, "top": 0, "width": 4, "height": 4},
         image_format="png",

--- a/tests/unit/vision/test_screenshot_bitblt_fault_tolerance.py
+++ b/tests/unit/vision/test_screenshot_bitblt_fault_tolerance.py
@@ -17,13 +17,22 @@ import time
 import types
 from uuid import uuid4
 
-import pytest
-
 # Ensure mss.exception is importable for the fake (it is a real dep).
 import mss.exception as _mss_exception
+import pytest
 
 from jarvis.core.protocols import Observation
 from jarvis.vision.context_provider import VisionContextProvider
+
+
+@pytest.fixture(autouse=True)
+def _screen_recording_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep BitBlt tests independent of the macOS TCC state of the host."""
+    import jarvis.vision.screenshot as screenshot_module
+
+    monkeypatch.setattr(
+        screenshot_module, "warn_if_screen_recording_denied", lambda: False
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -271,8 +280,8 @@ async def test_refresh_loop_bitblt_does_not_spam_log(tmp_path, monkeypatch, capl
     """
     monkeypatch.setitem(sys.modules, "mss", _make_fake_mss_fail_module())
 
-    from jarvis.vision.screenshot import ScreenshotSource  # noqa: PLC0415
     from jarvis.vision.engine import VisionEngine  # noqa: PLC0415
+    from jarvis.vision.screenshot import ScreenshotSource  # noqa: PLC0415
 
     # Build a real engine using a real ScreenshotSource (but with fake mss).
     # The UIA tree source is a simple null fake so it never errors.

--- a/tests/unit/web/test_mic_level_route.py
+++ b/tests/unit/web/test_mic_level_route.py
@@ -18,6 +18,14 @@ class _PermissionPort:
         return self.allowed
 
 
+@pytest.fixture(autouse=True)
+def _default_to_permissionless_test_platform(monkeypatch):
+    """Keep generic route tests independent of this Mac's TCC state."""
+    import jarvis.ui.web.settings_routes as settings_routes
+
+    monkeypatch.setattr(settings_routes.sys, "platform", "linux")
+
+
 @pytest.fixture
 def client(monkeypatch):
     import jarvis.speech.diagnose as d

--- a/uv.lock
+++ b/uv.lock
@@ -2553,7 +2553,7 @@ wheels = [
 
 [[package]]
 name = "personal-jarvis"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- publish Personal Jarvis 1.1.2 with every commit currently on the release line
- refresh hot-plugged audio input and voice-output device selection safely
- harden wake, realtime voice, model selection, mission, wiki, and macOS desktop behavior
- make Windows-specific paths and Registry behavior honest on macOS/Linux
- isolate tests from maintainer configuration, credentials, permissions, ports, windows, and audio devices

## Local verification

- 15,196 tests passed across unit, contract, integration, mission, and review suites
- portable install matrix: 24/24 scenarios passed
- release completeness, language, credential/private-key, docs privacy, public docs, CLI coverage, danger metadata, generated references, requirements sync, universal lockfile, frontend bundle, shell compatibility, and import cleanliness gates passed
- cold boot: window 641 ms, voice usable 8,619 ms, app interactive 8,699 ms; all below the enforced budgets

## Release

After required PR checks pass, merge this PR, tag `v1.1.2`, publish the GitHub Release and signed installer assets, upload `personal-jarvis-src.tar.gz`, then run the manual macOS/Windows/Linux CI and fresh-install matrices.