### PR TITLE
Release 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ versioning per [SemVer](https://semver.org/).
 
 ---
 
+## [1.1.4] — 2026-07-23
+
+### Added
+
+- **The bar is now yours to size.** A new "Bar size" slider in
+  Settings → Appearance live-resizes the JarvisBar and every surface it owns,
+  remembers your choice, and defaults to a larger, physical-size-consistent
+  135% so the bar looks the same on any screen. It is also reachable over the
+  API (`GET`/`PUT /api/settings/bar-size`).
+- **The bar follows you across monitors.** It moves to the monitor your mouse
+  is on, and dragging it from one screen to another now works correctly.
+- **Two more ways to run speech-to-text on a single key.** OpenAI Whisper and
+  Gemini cloud STT plugins let a downloader whose only credential is an OpenAI
+  or Google key dictate without a separate transcription provider.
+- A discreet, honest hint under the engine switch explains that single-mode
+  is about which API keys you hold, not a lesser mode.
+
+### Changed
+
+- **Opening an app now fills the screen.** `open_app` maximizes a freshly
+  launched window, and also maximizes an already-running one when it is
+  brought to the front.
+
+### Fixed
+
+- **Google Drive works again.** Drive now talks to Google's REST API directly
+  with the full scope instead of the hosted Drive connector, which only served
+  Workspace preview accounts and returned "403" for everyone else.
+- **A single plugin no longer takes the main brain down.** One tool's schema
+  used an object-key constraint (`propertyNames`) that Gemini rejects, which
+  had been failing the whole request and cascading through the provider chain;
+  those constraints are now stripped before the call.
+- **Hanging up from the bar can no longer freeze it or deafen the wake word.**
+  A realtime session's teardown is now time-bounded, so closing a call with
+  the bar's X no longer stalls on a slow provider or leaves the bar stuck
+  "listening".
+- **Escape and hang-up abort an on-screen action instantly**, even mid-step
+  while Computer-Use is still thinking, instead of only between steps.
+- **The wiki stops crying wolf.** A content judgment during curation is no
+  longer misreported as a provider chain failure, so the big red banner no
+  longer appears when nothing is actually broken.
+- Background text jobs cross to a different provider family when the default
+  Claude API path has no key, instead of dead-ending.
+- Telegram and Discord user-facing strings are now English.
+- On Linux, Computer-Use honestly reports characters it had to drop instead of
+  claiming success.
+- The custom wake-word onboarding copy is corrected and now provisions the
+  real Vosk fallback.
+- Delegated action turns answer in the same language as the rest of the
+  conversation.
+- Computer-Use recovers from Gemini's "thinking required" errors and no longer
+  falls back to a blind last-resort vision pass.
+
 ## [1.1.3] — 2026-07-21
 
 ### Added

--- a/jarvis/__init__.py
+++ b/jarvis/__init__.py
@@ -1,3 +1,3 @@
 """Personal Jarvis — a voice-driven, cross-platform meta-orchestrator."""
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"

--- a/jarvis/ui/web/frontend/src/views/ApiKeysView.two-mode.test.tsx
+++ b/jarvis/ui/web/frontend/src/views/ApiKeysView.two-mode.test.tsx
@@ -90,8 +90,10 @@ describe("ApiKeysView two-mode", () => {
     render(<ApiKeysView />);
     const hint = screen.getByTestId("voice-engine-keys-hint");
     expect(screen.getByTestId("voice-engine-context").contains(hint)).toBe(true);
-    // The load-bearing message: keys are only needed for the SELECTED mode.
-    expect(hint.textContent).toMatch(/only need api keys for the mode you use/i);
+    // The load-bearing message: which keys you need depends on the SELECTED mode.
+    expect(hint.textContent).toMatch(
+      /realtime needs one realtime-capable key; pipeline needs its own/i,
+    );
   });
 
   it("defaults to Pipeline mode showing Brain/Voice/Subagents tabs, no Realtime tab", () => {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "personal-jarvis"
-version = "1.1.3"
+version = "1.1.4"
 description = "Voice-driven meta-orchestrator that turns one spoken request into a fleet of self-checking AI agents"
 requires-python = ">=3.11,<3.15"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -2553,7 +2553,7 @@ wheels = [
 
 [[package]]
 name = "personal-jarvis"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Cuts release **1.1.4**: bumps the version in \`pyproject.toml\` + \`jarvis/__init__.py\` and adds the CHANGELOG entry, on top of the 25 feature/fix commits accumulated since 1.1.3.

## Highlights (see CHANGELOG.md for the full list)

**Added**
- User-adjustable "Bar size" slider (Settings → Appearance) with live resize + `GET`/`PUT /api/settings/bar-size`; defaults to a physical-size-consistent 135%.
- JarvisBar follows the mouse across monitors + fixed cross-monitor drag.
- OpenAI Whisper and Gemini cloud STT plugins for single-key downloaders.

**Changed**
- `open_app` maximizes freshly launched and refocused windows.

**Fixed**
- Native Google Drive REST tool + full scope (hosted connector 403'd consumer accounts).
- Strip JSON-schema object-key constraints Gemini rejects (a single plugin was taking the primary brain down).
- Bounded realtime session teardown so a bar-X hang-up can't freeze the bar or deafen wake.
- Esc/hang-up aborts a running Computer-Use step immediately.
- Wiki curation content verdict no longer raises the false provider chain-failure banner.
- Cross-family fallback for background resolver on a keyless claude-api default; English Telegram/Discord strings; honest non-ASCII drop reporting on Linux; corrected wake-word onboarding + real Vosk fallback; delegated turns keep the resolved output language; Computer-Use recovers Gemini thinking-400s.

## Notes
- Version verified: no `1.1.3` remains in code; `1.1.4` set in both manifest locations.
- No secrets, binaries, media, or local/video artifacts in the diff.