### PR TITLE
chore(deps): refresh certifi CA bundle + force Dependabot graph re-parse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -98,9 +98,9 @@ backports-tarfile==1.2.0 ; python_full_version < '3.12' \
     --hash=sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34 \
     --hash=sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991
     # via jaraco-context
-certifi==2026.6.17 \
-    --hash=sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432 \
-    --hash=sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db
+certifi==2026.7.22 \
+    --hash=sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775 \
+    --hash=sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55
     # via
     #   httpcore
     #   httpx

--- a/uv.lock
+++ b/uv.lock
@@ -449,11 +449,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.6.17"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Follow-up to the security dependency refresh (#69). Bumps `certifi` 2026.6.17 → 2026.7.22 (latest CA trust bundle).

The functional motivation: after #69 landed the patched Pillow/GitPython/pyasn1/setuptools versions on `main`, GitHub's **dependency graph still held the stale pre-fix entries** (pillow 12.2.0, gitpython 3.1.50 — confirmed via the repo's SBOM), which kept ~23 already-remediated Dependabot alerts open. GitHub only re-parses a lockfile's graph entry when that file's content changes on the default branch, so this commit re-writes `requirements.txt` + `uv.lock` (via the certifi bump) to force a clean re-parse that drops the stale entries.

The certifi refresh is itself legitimate and security-relevant (trust anchors); it has no runtime API surface.

## Type of change

- [x] Refactor / internal cleanup (no behavior change) — dependency/CA refresh

## Checklist

- [x] All artifacts are in English.
- [x] No secrets or personal data in the diff.
- [x] `requirements.txt` stays `--universal` + hash-pinned; `check_requirements_sync` and `check_lockfile_universal` pass.

## How was this tested?

- Only `certifi` changes in both lockfiles (6 lines each); `certifi==2026.7.22` has 0 known vulnerabilities.
- `check_requirements_sync.py` and `check_lockfile_universal.py` pass; `requirements.txt` remains a byte-reproducible universal/hash recompile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPMD18i6B14RztNLpUXrx9

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPMD18i6B14RztNLpUXrx9)_