### PR TITLE
chore(git): add .mailmap consolidating maintainer placeholder identities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -326,7 +326,3 @@ video/*.png
 # Internal trademark/brand risk assessment. A self-authored record of known,
 # deferred IP risk — keep it private; the public posture is TRADEMARK.md.
 /docs/legal/trademark-brand-audit-*.html
-
-# Author email map. Its stated purpose is to keep private addresses out of the
-# public index, but the file itself publishes them in plaintext.
-/.mailmap

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,22 @@
+# .mailmap — map historical placeholder identities onto the maintainer's
+# canonical GitHub identity so `git shortlog -sne` reports an honest picture.
+# The history itself is append-only and is never rewritten.
+#
+# Invariant (see scripts/ci/privacy_gate/references/scrub-exempt.txt): this
+# tracked file must NEVER contain a real personal e-mail address — only the
+# GitHub noreply form, project-generic addresses, and RFC-reserved
+# placeholders. A real address anywhere in history stays unmapped here.
+#
+# Deliberately not mapped: dependabot[bot], Claude, and other bot identities —
+# they are legitimately not the maintainer.
+
+# Canonical identity. This line also normalizes name-only variants
+# ("RubenLütke", "rubenluetke10-beep", "Personal Jarvis Maintainer") that
+# committed with the same address.
+Ruben Lütke <226271791+rubenluetke10-beep@users.noreply.github.com>
+
+# Early automation committed as a generic project identity.
+Ruben Lütke <226271791+rubenluetke10-beep@users.noreply.github.com> <noreply@personaljarvis.dev>
+
+# Placeholder identity from a misconfigured machine (example.com is RFC-reserved).
+Ruben Lütke <226271791+rubenluetke10-beep@users.noreply.github.com> <harald@example.com>

--- a/scripts/ci/privacy_gate/references/distribution-denylist.txt
+++ b/scripts/ci/privacy_gate/references/distribution-denylist.txt
@@ -33,15 +33,15 @@
 # to remove, and a fork generates its own. So withhold that whole subtree.
 scripts/ci/privacy_gate/**
 
-# --- .mailmap: full-depersonalization decision (2026-06-01) ------------------
-# The dist repo's history is already 100% noreply-authored (no real-email
-# commits exist there), so .mailmap maps nothing and is NOT load-bearing in the
-# distribution — it only ships the maintainer's two private emails + full name
-# as file data. Per the maintainer's "full depersonalization" choice for the
-# v0.1.0 release, drop it from the snapshot entirely (cleanest cut: removes both
-# real emails and the full name with zero scrub artifacts). reconcile deletes it
-# from the dist tree.
-.mailmap
+# --- .mailmap: shipped again since 2026-07-28 (maintainer directive) ---------
+# The 2026-06-01 full-depersonalization entry withheld .mailmap because it then
+# carried the maintainer's two private e-mail addresses as file data. That era
+# is retired (2026-07-17: one shared git history) and its premise no longer
+# holds either: the public history is NOT purely noreply-authored (generic
+# "Personal Jarvis Maintainer" and placeholder identities exist there), so the
+# file IS load-bearing for honest `git shortlog` attribution. The tracked
+# .mailmap now must never contain a real personal address (see
+# scrub-exempt.txt), which removes the reason to withhold it.
 
 # --- Encrypted release-signing keys (maintainer identity) -------------------
 install/keys/*.key.enc

--- a/scripts/ci/privacy_gate/references/scrub-exempt.txt
+++ b/scripts/ci/privacy_gate/references/scrub-exempt.txt
@@ -1,14 +1,18 @@
 # Paths exempt from the PII scrub (one gitignore-ish glob per line).
 #
-# 2026-07-20: the `.mailmap` exemption was REMOVED along with the file itself.
-# The reasoning it rested on does not survive scrutiny: `.mailmap` was exempted
-# so it could carry the real addresses as mapping keys, on the theory that this
-# defends against scrapers by rewriting them to the GitHub noreply form in the
-# web UI. But the file is world-readable in the repo, so the addresses were
-# published in plaintext to defend against them being published — the mapping
-# hides them in one view while the source shipped them in another. The file is
-# now untracked (and gitignored); a real address in ANY tracked file is a
-# finding again, with no exempt home. Do not re-add it.
+# 2026-07-20: the `.mailmap` exemption was REMOVED along with the file itself,
+# because the tracked file carried REAL personal addresses in plaintext —
+# publishing them in one view to hide them in another.
+# 2026-07-28 (maintainer directive): `.mailmap` is back and tracked, under a
+# stricter invariant that resolves the 2026-07-20 objection: the file must
+# NEVER contain a real personal e-mail address. It may only map the GitHub
+# noreply form, project-generic addresses (noreply@personaljarvis.dev), and
+# RFC-reserved placeholders (harald@example.com) onto the canonical identity.
+# This path is exempt because the generic name-scrub rules (e.g. "harald" ->
+# "sam") would otherwise corrupt the mapping keys, which must byte-match the
+# historical commit metadata to work. A real address appearing in this file is
+# STILL a finding — the sub-agent + human review remain the backstop for that.
+.mailmap
 
 # Maintainer's intentional authorship attribution (explicit decision 2026-06-26;
 # handle switched to @Ruben_Luetke on 2026-07-18):


### PR DESCRIPTION
Maps the generic 'Personal Jarvis Maintainer' identity, the RFC-reserved harald@example.com placeholder, and name-only variants of the canonical address onto the maintainer's GitHub noreply identity, so `git shortlog -sne` reports an honest contributor picture without rewriting history.

The tracked file deliberately contains **no real personal e-mail address** (invariant documented in `scripts/ci/privacy_gate/references/scrub-exempt.txt`). The privacy-gate exemption, denylist entry, and .gitignore entry from the retired full-depersonalization era are updated in the same change.

Not mapped on purpose: dependabot[bot], Claude, and other bot identities.