### PR TITLE
fix(deps): cap mcp below 2.0 until broker_stdio migrates to the v2 API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,12 @@ dependencies = [
     # transports (missing Host/Origin validation, unverified session
     # principal, cross-client task access) are fixed there — never resolve
     # lower (Dependabot #48-#51).
-    "mcp>=1.28.1",
+    # Ceiling <2: mcp 2.0.0 removes the low-level Server decorator API
+    # (@server.list_tools / @server.call_tool become constructor parameters)
+    # and stops auto-wrapping return values, which breaks
+    # jarvis/missions/workers/broker_stdio.py at import time. Lift the
+    # ceiling only together with a deliberate 2.x migration of that adapter.
+    "mcp>=1.28.1,<2",
     "rich>=13.9",
     # jarvisctl control CLI (jarvis/cli_ctl/): Typer command surface + platformdirs
     # for cross-platform per-user config/cache dirs. Pure-Python, VPS-safe.

--- a/requirements.in
+++ b/requirements.in
@@ -129,7 +129,7 @@ ddgs==9.14.3
 # transports (missing Host/Origin validation, unverified session principal,
 # cross-client task access) are fixed there — never resolve lower
 # (Dependabot #48-#51).
-mcp>=1.28.1
+mcp>=1.28.1,<2
 
 # CLI (setup wizard + jarvisctl control CLI)
 rich>=13.9


### PR DESCRIPTION
mcp 2.0.0 removes the low-level Server decorator API (`list_tools`/`call_tool` become constructor parameters) and stops auto-wrapping return values, which breaks `jarvis/missions/workers/broker_stdio.py` at import time. CI installs from the unpinned pyproject range and went red on main (jarvisctl unit: `AttributeError: 'Server' object has no attribute 'list_tools'`) while local environments stayed green on 1.28.1 — the AP-28 unpinned-lib trap.

The hash-locked `requirements.txt` already resolves to 1.28.1, so the lockfile is unchanged; `check_requirements_sync` and `check_lockfile_universal` pass. Lifting the ceiling is a deliberate follow-up: migrate the broker adapter to the v2 constructor-handler API first.