### PR TITLE
fix(deps): refresh uv.lock so the BLOCKING deps-sync CI gate passes again

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2553,7 +2553,7 @@ wheels = [
 
 [[package]]
 name = "personal-jarvis"
-version = "1.1.4"
+version = "1.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -2736,7 +2736,7 @@ requires-dist = [
     { name = "keyring", specifier = ">=25.5" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "markdown", specifier = ">=3.5" },
-    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "mss", marker = "extra == 'desktop'", specifier = ">=10.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
     { name = "num2words", specifier = ">=0.5.13" },


### PR DESCRIPTION
`uv lock --check` has been failing on `main`. With #78 having fixed the `jarvisctl` failure, **this is the last red job in the CI workflow.**

## Cause

Two changes edited `pyproject.toml` without regenerating the lockfile:

| Change | Left behind in `uv.lock` |
|---|---|
| The 1.1.5 release | `version = "1.1.4"` |
| #78 capping mcp | `mcp >=1.28.1` instead of `>=1.28.1,<2` |

## Fix

Regenerated with `uv lock` **inside a worktree of `public/main`**, not on the dev box — the local tree is 383 commits ahead, so locking there would have resolved against a different dependency set than CI sees.

The diff is exactly those two lines. **No dependency actually moved**, which is what makes this safe to land on its own rather than bundled with a release.

## Verification

- `uv lock --check` — fails before, passes after
- `check_lockfile_universal.py` — lockfile still platform-universal, free of GPU/CUDA/torch wheels
- `check_requirements_sync.py` — `requirements.in` still in lockstep with `pyproject.toml`