### PR TITLE
feat(packaging): sign the Windows setup through SignPath Foundation, and pack a Microsoft Store MSIX

### DIFF
--- a/.github/workflows/desktop-installers.yml
+++ b/.github/workflows/desktop-installers.yml
@@ -20,6 +20,18 @@
 # the environment variable instead. Without the secrets the build still
 # produces a working, unsigned installer and says so.
 #
+# Windows signing goes through SignPath Foundation (free code signing for open
+# source, https://signpath.org): the unsigned setup is uploaded as a workflow
+# artifact, SignPath fetches it by artifact id, signs it on its side with a
+# certificate issued to SignPath Foundation, and the signed file comes back.
+# No key material ever touches this runner. packaging/windows/README.md has
+# the SignPath-side configuration.
+#
+# The same job also packs the frozen bundle into an MSIX for the Microsoft
+# Store. It is deliberately unsigned: the Store re-signs it with Microsoft's
+# certificate after certification, and that signature - not ours - is what
+# spares a Store install the SmartScreen prompt.
+#
 # Action SHAs are pinned to 40-char commits (CVE-2025-30066 hardening), matching
 # the rest of this repo's workflows.
 
@@ -50,15 +62,15 @@ jobs:
     name: Windows installer (x64)
     runs-on: windows-latest
     timeout-minutes: 90
+    permissions:
+      contents: read
+      # The SignPath connector reads the unsigned artifact of this very run.
+      actions: read
     env:
       # Exported here (not per step) so the `if:` guards below can read them.
       # An empty value means "this fork has no signing secrets" - not an error.
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-      AZURE_SIGNING_ENDPOINT: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-      AZURE_CODE_SIGNING_ACCOUNT: ${{ secrets.AZURE_CODE_SIGNING_ACCOUNT }}
-      AZURE_CERTIFICATE_PROFILE: ${{ secrets.AZURE_CERTIFICATE_PROFILE }}
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+      SIGNPATH_ORGANIZATION_ID: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -105,28 +117,84 @@ jobs:
       # Signs the SETUP executable. Windows attaches Mark-of-the-Web to the
       # downloaded installer, so this signature is the one SmartScreen weighs;
       # files the installer then writes inherit no MOTW.
-      - name: Sign the installer (Azure Trusted Signing)
-        if: env.AZURE_CLIENT_ID != ''
-        # pin: azure/trusted-signing-action@v2.0.0 - pinned by commit SHA.
-        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82
+      #
+      # SignPath reads the file from a workflow artifact, not from the runner,
+      # so the unsigned setup is uploaded first and referenced by artifact id.
+      - name: Upload the unsigned installer for SignPath
+        id: unsigned
+        if: env.SIGNPATH_API_TOKEN != ''
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          trusted-signing-account-name: ${{ secrets.AZURE_CODE_SIGNING_ACCOUNT }}
-          certificate-profile-name: ${{ secrets.AZURE_CERTIFICATE_PROFILE }}
-          files-folder: ${{ github.workspace }}/dist/installers
-          files-folder-filter: exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
+          name: installer-windows-x64-unsigned
+          path: dist/installers/PersonalJarvis-Setup-x64.exe
+          if-no-files-found: error
+          retention-days: 3
+
+      - name: Sign the installer (SignPath Foundation)
+        if: env.SIGNPATH_API_TOKEN != ''
+        # pin: signpath/github-action-submit-signing-request@v2 - pinned by commit SHA.
+        uses: signpath/github-action-submit-signing-request@c92b958760219087e01f8d67a1669ed57afe2627
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
+          # Slugs are not secrets; override them as repository variables when
+          # the SignPath project is named differently.
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG || 'PersonalJarvis' }}
+          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG || 'release-signing' }}
+          github-artifact-id: ${{ steps.unsigned.outputs.artifact-id }}
+          wait-for-completion: true
+          # A release signing request is approved by hand on SignPath's side;
+          # give the approver half an hour before the job gives up.
+          wait-for-completion-timeout-in-seconds: 1800
+          output-artifact-directory: dist/signed
+
+      - name: Verify the signature and put the signed file in place
+        if: env.SIGNPATH_API_TOKEN != ''
+        shell: pwsh
+        run: |
+          $signed = Get-ChildItem -Path dist/signed -Recurse -Filter PersonalJarvis-Setup-x64.exe |
+            Select-Object -First 1
+          if (-not $signed) {
+            Write-Error "SignPath returned no PersonalJarvis-Setup-x64.exe under dist/signed"
+            exit 1
+          }
+          $sig = Get-AuthenticodeSignature -FilePath $signed.FullName
+          if ($sig.Status -ne 'Valid') {
+            Write-Error "Authenticode status of the signed installer is $($sig.Status), not Valid"
+            exit 1
+          }
+          Write-Host "Signed by: $($sig.SignerCertificate.Subject)"
+          Copy-Item -Path $signed.FullName -Destination dist/installers/PersonalJarvis-Setup-x64.exe -Force
 
       - name: Report the signing state honestly
-        if: env.AZURE_CLIENT_ID == ''
+        if: env.SIGNPATH_API_TOKEN == ''
         shell: bash
         run: |
-          echo "::notice::AZURE_* signing secrets are not configured - the installer is UNSIGNED."
+          echo "::notice::SIGNPATH_* secrets are not configured - the installer is UNSIGNED."
+
+      # Microsoft Store package. Built from the same frozen bundle the setup
+      # wraps, so a Store install and a downloaded install are the same
+      # program. Unsigned on purpose (see the header); an unsigned MSIX cannot
+      # be sideloaded, so it is a workflow artifact for the Partner Center
+      # upload and never a release asset.
+      - name: Build the Microsoft Store package (MSIX)
+        shell: pwsh
+        env:
+          # Partner Center hands out all three after the app name is reserved
+          # (Product identity page). Until then the script packs with
+          # placeholders makeappx accepts, so the path is exercised on every run.
+          MSSTORE_IDENTITY_NAME: ${{ vars.MSSTORE_IDENTITY_NAME }}
+          MSSTORE_PUBLISHER: ${{ vars.MSSTORE_PUBLISHER }}
+          MSSTORE_PUBLISHER_DISPLAY_NAME: ${{ vars.MSSTORE_PUBLISHER_DISPLAY_NAME }}
+        run: pwsh packaging/windows/build-msix.ps1 -SkipPyInstaller
+
+      - name: Upload the Store package
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: msix-windows-x64
+          path: dist/installers/PersonalJarvis-x64.msix
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Upload the installer
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -1,0 +1,108 @@
+# Windows packaging
+
+Two packages come out of the same frozen bundle (`dist\Jarvis`, built by
+`jarvis.spec`):
+
+| Script | Output | Who installs it |
+| --- | --- | --- |
+| `build.ps1` | `dist\installers\PersonalJarvis-Setup-x64.exe` - per-user Inno Setup wizard | the website's download button, the in-app updater |
+| `build-msix.ps1 -SkipPyInstaller` | `dist\installers\PersonalJarvis-x64.msix` - Microsoft Store package | Partner Center only (see below) |
+
+Both run unchanged on a maintainer's machine and in
+`.github/workflows/desktop-installers.yml`, so a green CI run means the
+documented command works.
+
+## Why there are two ways past SmartScreen
+
+Windows SmartScreen warns on any downloaded executable it has no reputation
+for. Reputation is earned per signing certificate over weeks of clean
+installs; a fresh certificate - paid or free, OV or EV - starts at zero, and
+an unsigned file starts at zero again with **every release**. Microsoft's own
+guidance ([SmartScreen reputation](https://learn.microsoft.com/windows/apps/package-and-deploy/smartscreen-reputation))
+names two remedies, and this repository uses both:
+
+1. **Sign the setup** so reputation accrues on the certificate and carries
+   over from release to release. The certificate comes from the
+   [SignPath Foundation](https://signpath.org), which signs open-source
+   projects for free; the publisher shown on the file is
+   *SignPath Foundation*.
+2. **Publish through the Microsoft Store.** The Store re-signs the package
+   with Microsoft's certificate; a Store install never sees the SmartScreen
+   prompt at all, and `winget install` can point at the Store listing.
+
+## Code signing (SignPath Foundation)
+
+The workflow's `windows` job uploads the unsigned setup as the artifact
+`installer-windows-x64-unsigned`, submits it to SignPath by artifact id,
+waits for the signed file, verifies the Authenticode signature with
+`Get-AuthenticodeSignature`, and only then lets the file become
+`installer-windows-x64` for the release. No private key ever exists on the
+runner or in this repository. Without the secrets the job builds an unsigned
+setup and prints a notice - a fork is not broken by not being SignPath's
+project.
+
+Secrets (Settings > Secrets and variables > Actions):
+
+| Name | Kind | Value |
+| --- | --- | --- |
+| `SIGNPATH_API_TOKEN` | secret | API token of a SignPath user with the *Submitter* role on the project |
+| `SIGNPATH_ORGANIZATION_ID` | secret | the organization id SignPath shows under Settings |
+| `SIGNPATH_PROJECT_SLUG` | variable, optional | defaults to `PersonalJarvis` |
+| `SIGNPATH_SIGNING_POLICY_SLUG` | variable, optional | defaults to `release-signing` |
+
+SignPath-side configuration, once the Foundation has approved the project:
+
+1. In the SignPath project, connect the **GitHub Actions trusted build
+   system** to `PersonalJarvis/PersonalJarvis` (Trusted build systems >
+   GitHub). This is what lets SignPath verify that a signing request really
+   came from a workflow run on this repository, not from a laptop.
+2. Add an **artifact configuration** for the setup. GitHub artifacts arrive
+   as a zip, so the configuration wraps the executable:
+
+   ```xml
+   <artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+     <zip-file>
+       <pe-file path="PersonalJarvis-Setup-x64.exe">
+         <authenticode-sign />
+       </pe-file>
+     </zip-file>
+   </artifact-configuration>
+   ```
+
+3. Create the signing policy `release-signing` with the Foundation's release
+   certificate, **manual approval** on, and the origin restricted to tags of
+   this repository. Every release signature is then a click by the approver
+   named in the [code signing policy](https://personaljarvis.ai/docs/code-signing/).
+
+The website's policy page and the installation guide say the project uses
+SignPath Foundation; keep them in step with this file when anything here
+changes.
+
+## Microsoft Store package (MSIX)
+
+`build-msix.ps1` stages `dist\Jarvis` unchanged, renders the Store tiles from
+`assets\icons\jarvis-gigi-256.png`, fills `msix\AppxManifest.xml` and packs
+the folder with `makeappx` from the Windows SDK (preinstalled on GitHub's
+`windows-latest`). The package is **unsigned on purpose**: an unsigned MSIX
+cannot be installed by double-click, and the Store signs it itself after
+certification. It is therefore a workflow artifact (`msix-windows-x64`), not a
+release asset, and the website never links to it.
+
+The identity has to match what Partner Center reserved for the app name, or
+the submission is rejected. Set these repository **variables** from
+Partner Center > the app > Product management > Product identity:
+
+| Variable | Manifest field |
+| --- | --- |
+| `MSSTORE_IDENTITY_NAME` | `Package/Identity/Name` |
+| `MSSTORE_PUBLISHER` | `Package/Identity/Publisher` (`CN=...`) |
+| `MSSTORE_PUBLISHER_DISPLAY_NAME` | `Package/Properties/PublisherDisplayName` |
+
+Without them the script packs with placeholders and warns, so the packaging
+path is exercised on every run while the Store safety net stays in place.
+
+Submitting a release: download the `msix-windows-x64` artifact of the tag's
+workflow run and upload it in Partner Center > the app > Packages. The
+manifest declares `runFullTrust` (the app is a classic Win32 program), the
+`microphone` device capability and `internetClient`; the Store lists those on
+the product page.

--- a/packaging/windows/build-msix.ps1
+++ b/packaging/windows/build-msix.ps1
@@ -1,0 +1,181 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Pack the frozen Personal Jarvis bundle into an MSIX for the Microsoft Store.
+
+.DESCRIPTION
+    Runs after build.ps1 (or on its own with the PyInstaller step) and:
+        1. stages dist\Jarvis into dist\msix\ unchanged,
+        2. renders the Store tile images from assets\icons\jarvis-gigi-256.png,
+        3. fills packaging\windows\msix\AppxManifest.xml,
+        4. packs the folder with makeappx from the Windows SDK.
+
+    The result is dist\installers\PersonalJarvis-x64.msix.
+
+    The package is NOT signed. The Store signs an MSIX with Microsoft's own
+    certificate after certification, and that is the signature that makes a
+    Store install free of the SmartScreen prompt. An unsigned MSIX cannot be
+    installed by double-click, so this file is only ever uploaded to Partner
+    Center - it is not a release asset and the website never links to it.
+
+.PARAMETER SkipPyInstaller
+    Package the existing dist\Jarvis instead of freezing again. CI passes this
+    because build.ps1 has just produced the bundle the setup wraps, and the
+    Store package must be that same bundle.
+
+.NOTES
+    Identity comes from the environment so the values live in one place
+    (GitHub repository variables), never in a file:
+
+        MSSTORE_IDENTITY_NAME            Package/Identity/Name from Partner Center
+        MSSTORE_PUBLISHER                Package/Identity/Publisher (CN=...)
+        MSSTORE_PUBLISHER_DISPLAY_NAME   Package/Properties/PublisherDisplayName
+
+    Without them the script uses placeholders that makeappx accepts, so the
+    packaging path is exercised on every CI run; the Store rejects a package
+    whose identity does not match the reserved app name, which is the intended
+    safety net.
+#>
+[CmdletBinding()]
+param(
+    [switch] $SkipPyInstaller
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Write-Step([string] $Message) { Write-Host "==> $Message" -ForegroundColor Cyan }
+function Stop-WithError([string] $Message) { Write-Error $Message; exit 1 }
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$BundleDir = Join-Path $RepoRoot "dist\Jarvis"
+$StageDir = Join-Path $RepoRoot "dist\msix"
+$InstallerDir = Join-Path $RepoRoot "dist\installers"
+$ManifestTemplate = Join-Path $PSScriptRoot "msix\AppxManifest.xml"
+$IconSource = Join-Path $RepoRoot "assets\icons\jarvis-gigi-256.png"
+$GuiExeName = "PersonalJarvis.exe"
+$OutputFile = Join-Path $InstallerDir "PersonalJarvis-x64.msix"
+
+if (-not (Test-Path $ManifestTemplate)) { Stop-WithError "manifest template not found at $ManifestTemplate" }
+if (-not (Test-Path $IconSource)) { Stop-WithError "icon source not found at $IconSource" }
+
+# --- Version ---------------------------------------------------------------
+# Same single source of truth as build.ps1. MSIX wants four numeric parts and
+# reserves the last one for the Store, so 1.6.0 becomes 1.6.0.0.
+$InitText = Get-Content (Join-Path $RepoRoot "jarvis\__init__.py") -Raw
+$VersionMatch = [regex]::Match($InitText, '__version__\s*=\s*"([^"]+)"')
+if (-not $VersionMatch.Success) { Stop-WithError "jarvis/__init__.py does not define __version__" }
+$AppVersion = $VersionMatch.Groups[1].Value
+$NumericMatch = [regex]::Match($AppVersion, '^(\d+)\.(\d+)\.(\d+)')
+if (-not $NumericMatch.Success) { Stop-WithError "version '$AppVersion' does not start with MAJOR.MINOR.PATCH" }
+$MsixVersion = "{0}.{1}.{2}.0" -f $NumericMatch.Groups[1].Value, $NumericMatch.Groups[2].Value, $NumericMatch.Groups[3].Value
+Write-Step "Personal Jarvis $AppVersion -> MSIX version $MsixVersion"
+
+# --- Identity --------------------------------------------------------------
+function Get-EnvOrDefault([string] $Name, [string] $Default) {
+    $value = [Environment]::GetEnvironmentVariable($Name)
+    if ([string]::IsNullOrWhiteSpace($value)) { return $Default }
+    return $value.Trim()
+}
+$IdentityName = Get-EnvOrDefault "MSSTORE_IDENTITY_NAME" "PersonalJarvis.PersonalJarvis"
+# A plain distinguished name: makeappx validates the Publisher as X.500, so
+# the placeholder must already be one.
+$Publisher = Get-EnvOrDefault "MSSTORE_PUBLISHER" "CN=PersonalJarvisPlaceholder"
+$PublisherDisplayName = Get-EnvOrDefault "MSSTORE_PUBLISHER_DISPLAY_NAME" "Personal Jarvis"
+if ($Publisher -eq "CN=PersonalJarvisPlaceholder") {
+    Write-Warning "MSSTORE_PUBLISHER is not set - packing with a placeholder identity. The Store will reject this package; set the repository variables from Partner Center for a real submission."
+}
+
+# --- 1. The frozen bundle --------------------------------------------------
+if ($SkipPyInstaller) {
+    Write-Step "1/4 reusing the existing bundle (-SkipPyInstaller)"
+} else {
+    Write-Step "1/4 freezing with PyInstaller"
+    Push-Location $RepoRoot
+    try {
+        & python -m PyInstaller jarvis.spec --noconfirm --clean
+        if ($LASTEXITCODE -ne 0) { Stop-WithError "pyinstaller exited with $LASTEXITCODE" }
+    } finally { Pop-Location }
+}
+if (-not (Test-Path (Join-Path $BundleDir $GuiExeName))) {
+    Stop-WithError "the frozen bundle is missing $GuiExeName (expected under $BundleDir) - run packaging\windows\build.ps1 first"
+}
+
+# --- 2. Stage --------------------------------------------------------------
+Write-Step "2/4 staging the bundle into $StageDir"
+if (Test-Path $StageDir) { Remove-Item -Recurse -Force $StageDir }
+New-Item -ItemType Directory -Force -Path $StageDir | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $StageDir "Assets") | Out-Null
+# robocopy exit codes below 8 mean "copied" - it is the one tool here whose
+# success is not exit 0.
+& robocopy $BundleDir $StageDir /E /NFL /NDL /NJH /NJS /NC /NS /NP | Out-Null
+if ($LASTEXITCODE -ge 8) { Stop-WithError "robocopy failed with $LASTEXITCODE" }
+$global:LASTEXITCODE = 0
+
+# --- 3. Tiles + manifest ---------------------------------------------------
+# The Store wants the tiles as PNGs at fixed sizes. Pillow is a core
+# dependency of the app, so the interpreter that built the bundle can render
+# them; the mascot is centred on the brand's matte black, never stretched.
+Write-Step "3/4 rendering tiles and writing AppxManifest.xml"
+$TileScript = @'
+import sys
+from pathlib import Path
+from PIL import Image
+
+src = Path(sys.argv[1])
+out = Path(sys.argv[2])
+icon = Image.open(src).convert("RGBA")
+tiles = {
+    "Square44x44Logo.png": (44, 44),
+    "Square150x150Logo.png": (150, 150),
+    "Wide310x150Logo.png": (310, 150),
+    "StoreLogo.png": (50, 50),
+}
+for name, (w, h) in tiles.items():
+    canvas = Image.new("RGBA", (w, h), (10, 10, 10, 255))
+    side = int(min(w, h) * 0.8)
+    glyph = icon.resize((side, side), Image.LANCZOS)
+    canvas.alpha_composite(glyph, ((w - side) // 2, (h - side) // 2))
+    canvas.save(out / name, "PNG")
+print("tiles:", ", ".join(tiles))
+'@
+$TileScriptPath = Join-Path $StageDir "..\msix-tiles.py"
+Set-Content -Path $TileScriptPath -Value $TileScript -Encoding UTF8
+& python $TileScriptPath $IconSource (Join-Path $StageDir "Assets")
+if ($LASTEXITCODE -ne 0) { Stop-WithError "tile rendering failed with $LASTEXITCODE" }
+Remove-Item $TileScriptPath -Force
+
+$Manifest = Get-Content $ManifestTemplate -Raw
+$Manifest = $Manifest.Replace("{{IdentityName}}", $IdentityName)
+$Manifest = $Manifest.Replace("{{Publisher}}", $Publisher)
+$Manifest = $Manifest.Replace("{{PublisherDisplayName}}", $PublisherDisplayName)
+$Manifest = $Manifest.Replace("{{Version}}", $MsixVersion)
+$Manifest = $Manifest.Replace("{{Executable}}", $GuiExeName)
+if ($Manifest -match "\{\{[A-Za-z]+\}\}") { Stop-WithError "unfilled placeholder left in the manifest: $($Matches[0])" }
+# makeappx reads the manifest as UTF-8 without a byte-order mark.
+[IO.File]::WriteAllText((Join-Path $StageDir "AppxManifest.xml"), $Manifest, (New-Object Text.UTF8Encoding $false))
+
+# --- 4. Pack ---------------------------------------------------------------
+Write-Step "4/4 packing with makeappx"
+$KitsRoot = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin"
+$MakeAppx = $null
+if (Test-Path $KitsRoot) {
+    $MakeAppx = Get-ChildItem -Path $KitsRoot -Directory |
+        Where-Object { $_.Name -match '^10\.' } |
+        Sort-Object { [version] $_.Name } -Descending |
+        ForEach-Object { Join-Path $_.FullName "x64\makeappx.exe" } |
+        Where-Object { Test-Path $_ } |
+        Select-Object -First 1
+}
+if (-not $MakeAppx) {
+    Stop-WithError "makeappx.exe not found under $KitsRoot - install the Windows 10/11 SDK (it is preinstalled on GitHub's windows-latest runners)"
+}
+Write-Host "makeappx: $MakeAppx"
+New-Item -ItemType Directory -Force -Path $InstallerDir | Out-Null
+if (Test-Path $OutputFile) { Remove-Item $OutputFile -Force }
+& $MakeAppx pack /d $StageDir /p $OutputFile /o
+if ($LASTEXITCODE -ne 0) { Stop-WithError "makeappx exited with $LASTEXITCODE" }
+if (-not (Test-Path $OutputFile)) { Stop-WithError "makeappx reported success but $OutputFile is missing" }
+
+$SizeMb = [math]::Round((Get-Item $OutputFile).Length / 1MB, 1)
+Write-Step "done: $OutputFile ($SizeMb MB, identity $IdentityName, publisher $Publisher)"

--- a/packaging/windows/msix/AppxManifest.xml
+++ b/packaging/windows/msix/AppxManifest.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Microsoft Store package manifest for Personal Jarvis.
+
+  build-msix.ps1 fills the {{...}} placeholders and copies this file to the
+  root of the staged package before makeappx packs it. Nothing else here is
+  generated, so what the Store certifies is what is in git.
+
+  Identity/Name and Identity/Publisher are assigned by Partner Center when the
+  app name is reserved (Product management > Product identity). They come in
+  as MSSTORE_IDENTITY_NAME and MSSTORE_PUBLISHER; the Store rejects a package
+  whose identity does not match the reservation, so placeholders only ever
+  produce a package for testing the packaging itself.
+
+  runFullTrust: the app is a classic Win32 program (a PyInstaller bundle). It
+  runs with the user's rights, outside the UWP sandbox, which is what lets it
+  drive other windows, read the screen and talk to the microphone the way the
+  downloaded installer's copy does. The Store shows this capability on the
+  listing; it is not a special permission the user grants.
+-->
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap rescap">
+
+  <Identity
+    Name="{{IdentityName}}"
+    Publisher="{{Publisher}}"
+    Version="{{Version}}"
+    ProcessorArchitecture="x64" />
+
+  <Properties>
+    <DisplayName>Personal Jarvis</DisplayName>
+    <PublisherDisplayName>{{PublisherDisplayName}}</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+    <Description>Open-source, bring-your-own-key desktop AI with voice, screen awareness and coding agents, running on your own machine.</Description>
+  </Properties>
+
+  <Dependencies>
+    <!-- 10.0.17763 is Windows 10 1809, the floor for MSIX itself. -->
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.22631.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="en-us" />
+  </Resources>
+
+  <Applications>
+    <Application Id="PersonalJarvis" Executable="{{Executable}}" EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements
+        DisplayName="Personal Jarvis"
+        Description="Open-source, bring-your-own-key desktop AI with voice, screen awareness and coding agents, running on your own machine."
+        BackgroundColor="#0A0A0A"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" />
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <Capability Name="internetClient" />
+    <rescap:Capability Name="runFullTrust" />
+    <DeviceCapability Name="microphone" />
+  </Capabilities>
+</Package>


### PR DESCRIPTION
## What does this PR do?

Replaces the paid Azure Trusted Signing step with free code signing through the [SignPath Foundation](https://signpath.org), and adds a Microsoft Store package (MSIX) built from the same frozen bundle. Both are the remedies Microsoft's own [SmartScreen guidance](https://learn.microsoft.com/windows/apps/package-and-deploy/smartscreen-reputation) names: a consistent signing certificate so reputation carries from release to release, and the Store, whose own re-signing spares an install the SmartScreen prompt entirely. Everything stays secret-gated - without `SIGNPATH_*` the build is unsigned and says so, and the MSIX packs with placeholders until Partner Center assigns the identity.

## Related issue

none

---

## Everyone

- [x] **English only** - code, comments, docs, commit messages, and this PR text.
- [x] **One logical change.** Unrelated fixes go in their own PR.
- [x] **No secrets, API keys, or personal data** anywhere in the diff.

## Then pick your block

<details open>
<summary><b>Change to a shared contract (release workflow)</b></summary>

- [x] Windows only: the `windows` job of `desktop-installers.yml`. macOS and Linux jobs are unchanged. The release asset names and the checksum manifest are unchanged, so the website's download routes and the in-app updater are not affected.
- [x] Without secrets the job behaves as before (unsigned setup + notice); the new MSIX step runs on every build and fails loudly if `makeappx` or the bundle is missing.
- [x] `packaging/windows/README.md` documents the SignPath project setup (artifact configuration, signing policy, trusted build system) and the Partner Center variables.

</details>

## How did you test it?

- `desktop-installers.yml` parsed with PyYAML; `AppxManifest.xml` parsed with `xml.dom.minidom` (Windows 11).
- `build-msix.ps1` parse-checked with the PowerShell AST parser and dry-run with `-SkipPyInstaller` against a stub `dist\Jarvis` on Windows 11: staging, tile rendering (44/150/310x150/50 px PNGs from the mascot) and manifest filling succeed; step 4 stops only because this machine has no Windows SDK, with the documented message. `makeappx` is preinstalled on `windows-latest`.
- The SignPath step cannot run until the Foundation approves the project and the secrets exist; the action is pinned to the v2 commit `c92b958760219087e01f8d67a1669ed57afe2627`.
