### PR TITLE
fix(voice): prevent cold-start freezes and isolate dictation recovery

### DIFF
--- a/jarvis/brain/manager.py
+++ b/jarvis/brain/manager.py
@@ -123,7 +123,7 @@ from .provider_registry import BrainProviderRegistry
 from .rate_limit_tracker import RateLimitTracker
 from .streaming import aggregate
 from .tool_call_recovery import extract_leaked_tool_calls
-from .tool_surface import maybe_reconcile_tool_surface, stamp_tool_surface
+from .tool_surface import stamp_tool_surface
 from .turn_planner import is_contextual_follow_up, plan_turn
 from .voice_command_gate import match_voice_command
 
@@ -10758,7 +10758,9 @@ class BrainManager:
         # session and the model refuses with "tool not available". Cheap
         # names-only drift check against the live CLI/plugin/MCP caches; one
         # refresh_tools() when they diverge. Never raises.
-        maybe_reconcile_tool_surface(self)
+        from jarvis.brain.tool_surface import reconcile_tool_surface_async
+
+        await reconcile_tool_surface_async(self)
 
         # auto mode: resolve this turn's language so _reply_language_directive()
         # hard-pins it (a soft "mirror" drifts to German on tool-synthesis
@@ -12876,21 +12878,44 @@ class BrainManager:
     # ------------------------------------------------------------------
 
     def refresh_tools(self) -> None:
-        """Reloads the tool dict from the factory.
+        """Synchronous refresh for callers outside the running event loop."""
+        snapshot = self._build_tool_snapshot()
+        if snapshot is not None:
+            self._apply_tool_snapshot(snapshot)
 
-        Triggered by the ``BrainToolsChanged`` event handler (see
-        ``attach_to_bus``) after a new CLI connects. Idempotent — if the
-        factory returns the same dict, effectively nothing changes.
+    async def refresh_tools_async(self) -> None:
+        """Coalesce registry events and build snapshots without blocking the loop."""
+        self._tool_refresh_pending = True
+        task = getattr(self, "_tool_refresh_task", None)
+        if task is None or task.done():
+            async def refresh() -> None:
+                from jarvis.brain.tool_surface import live_tool_surface_fingerprint
 
-        The simplest approach runs through ``_load_tools_for_tier`` and
-        replaces ``self._tools`` in-place. The tier is derived from an
-        internally set marker (the factory sets ``_tier`` during build).
-        If no tier is known, the tool dict stays unchanged — the user must
-        restart manually in that case.
+                while self._tool_refresh_pending:
+                    self._tool_refresh_pending = False
+                    before = live_tool_surface_fingerprint()
+                    snapshot = await asyncio.to_thread(self._build_tool_snapshot)
+                    if snapshot is not None:
+                        self._apply_tool_snapshot(snapshot)
+                        if live_tool_surface_fingerprint() != before:
+                            self._tool_refresh_pending = True
+
+            task = asyncio.create_task(refresh(), name="brain-tool-refresh")
+            self._tool_refresh_task = task
+        # A cancelled subscriber/turn must not abandon a registry refresh that
+        # other subscribers are awaiting, or cause another concurrent build.
+        await asyncio.shield(task)
+
+    def _build_tool_snapshot(self):
+        """Build replacement dictionaries while preserving the boot-time DI.
+
+        Plugin imports and entry-point scans can block for seconds on cold
+        storage. Running-loop callers execute this on a worker and publish
+        the complete result back on the loop. No tier means no replacement.
         """
         tier = getattr(self, "_tier", None)
         if not tier:
-            log.debug("refresh_tools: kein _tier gesetzt, skip")
+            log.debug("refresh_tools: no tier set; skipping")
             return
         try:
             # Lazy import: the factory may pull in heavy modules depending on
@@ -12908,7 +12933,7 @@ class BrainManager:
                 ToolExecutor,
             )
         except Exception as exc:  # noqa: BLE001
-            log.warning("refresh_tools: Factory-Module nicht importierbar: %s", exc)
+            log.warning("refresh_tools: factory modules could not be imported: %s", exc)
             return
 
         try:
@@ -12932,7 +12957,7 @@ class BrainManager:
 
             harness_manager = HarnessManager(bus=self._bus)
 
-            # ROOT CAUSE of the "der lokale Verlaufsspeicher ist nicht verfügbar"
+            # ROOT CAUSE of the "local history store is unavailable"
             # voice bug (live 2026-06-18): this rebuild — triggered by EVERY
             # CLI/MCP connect at boot ("Tool-Registry refreshed: 29 -> 107") —
             # used to drop the four shared DI references the boot path passes, so
@@ -12961,9 +12986,13 @@ class BrainManager:
                 config=self._config,
             )
         except Exception as exc:  # noqa: BLE001
-            log.warning("refresh_tools: Factory-Call fehlgeschlagen: %s", exc)
+            log.warning("refresh_tools: factory call failed: %s", exc)
             return
 
+        return new_tools, new_local_action_tools
+
+    def _apply_tool_snapshot(self, snapshot) -> None:
+        new_tools, new_local_action_tools = snapshot
         old_count = len(self._tools)
         self._tools = new_tools
         self._local_action_tools = new_local_action_tools
@@ -13002,8 +13031,8 @@ class BrainManager:
             return
 
         async def _on_tools_changed(ev: BrainToolsChanged) -> None:
-            log.info("BrainToolsChanged empfangen (reason=%s) -> refresh_tools()", ev.reason)
-            self.refresh_tools()
+            log.info("BrainToolsChanged received (reason=%s); refreshing tools", ev.reason)
+            await self.refresh_tools_async()
 
         target_bus.subscribe(BrainToolsChanged, _on_tools_changed)
         target_bus.subscribe(AnnouncementRequested, self._on_cu_tool_completion)

--- a/jarvis/brain/tool_surface.py
+++ b/jarvis/brain/tool_surface.py
@@ -14,6 +14,7 @@ LLM — AP-11 safe) against the fingerprint stamped at the last tool load, and
 triggers one ``refresh_tools()`` on drift. Whatever upstream event went
 missing, the tool surface converges at the next turn.
 """
+
 from __future__ import annotations
 
 import logging
@@ -64,9 +65,7 @@ def live_tool_surface_fingerprint() -> frozenset[str] | None:
             readable = True
             for server_name, client in mcp_registry.active_clients().items():
                 for tool_def in getattr(client, "_tools_cache", None) or []:
-                    tool_name = (
-                        tool_def.get("name") if isinstance(tool_def, dict) else None
-                    )
+                    tool_name = tool_def.get("name") if isinstance(tool_def, dict) else None
                     if tool_name:
                         names.add(f"mcp:{server_name}:{tool_name}")
     except Exception:  # noqa: BLE001
@@ -116,6 +115,21 @@ def maybe_reconcile_tool_surface(manager) -> None:
         manager.refresh_tools()
     except Exception:  # noqa: BLE001 — reconcile must never break a turn
         log.debug("tool-surface reconcile failed", exc_info=True)
+
+
+async def reconcile_tool_surface_async(manager) -> None:
+    """Refresh a missed registry change before a turn, keeping disk IO off-loop."""
+    try:
+        fingerprint = live_tool_surface_fingerprint()
+        if fingerprint is None:
+            return
+        previous = getattr(manager, "_tool_surface_fp", None)
+        if previous is None:
+            manager._tool_surface_fp = fingerprint
+        elif fingerprint != previous:
+            await manager.refresh_tools_async()
+    except Exception:  # noqa: BLE001 — a failed reconcile must not break a turn
+        log.debug("async tool-surface reconcile failed", exc_info=True)
 
 
 __all__ = [

--- a/jarvis/dictation/local_final.py
+++ b/jarvis/dictation/local_final.py
@@ -126,11 +126,13 @@ class LocalFinalSTT:
         *,
         min_free_gb: float = DEFAULT_MIN_FREE_GB,
         compute: str = FINAL_COMPUTE,
+        allow_cpu: bool = False,
         beam_size: int = FINAL_BEAM_SIZE,
     ) -> None:
         self._model_name = str(model_name or DEFAULT_FINAL_MODEL).strip()
         self._min_free_gb = max(0.0, float(min_free_gb))
         self._compute = compute
+        self._allow_cpu = allow_cpu
         self._beam_size = max(1, int(beam_size))
         self._worker: Any = None
         self._device = ""
@@ -233,15 +235,41 @@ class LocalFinalSTT:
                 f"the dictation worker takes 16 kHz audio, not {sample_rate} Hz"
             )
         if not self._call_lock.acquire(blocking=False):
-            self.recover()
+            await asyncio.to_thread(self.recover)
             raise LocalEngineUnavailable(
                 "a previous call is still waiting on the dictation worker; "
                 "it was replaced — this call goes to the next provider"
             )
+        # The blocking reader owns the guard, including after cancellation of
+        # its asyncio waiter. Releasing it on timeout lets the next request
+        # consume the previous request's response from the same pipe (AP-24).
+        guard = self._call_lock
+
+        def read() -> Transcript:
+            try:
+                return self._transcribe_blocking(pcm_bytes, language)
+            finally:
+                guard.release()
+
+        work = asyncio.create_task(asyncio.to_thread(read))
         try:
-            return await asyncio.to_thread(self._transcribe_blocking, pcm_bytes, language)
-        finally:
-            self._call_lock.release()
+            return await asyncio.shield(work)
+        except asyncio.CancelledError:
+            # Keep a cold build single-flight. An active decoder, however,
+            # must be killed so its blocked pipe reader can finish.
+            if self._worker is not None:
+                await asyncio.to_thread(self.recover)
+
+            def consume(done: asyncio.Task) -> None:
+                try:
+                    done.result()
+                except asyncio.CancelledError:
+                    pass  # Loop shutdown cancels this detached observer.
+                except Exception:
+                    log.debug("Abandoned dictation reader finished", exc_info=True)
+
+            work.add_done_callback(consume)
+            raise
 
     def _transcribe_blocking(self, pcm_bytes: bytes, language: str | None) -> Transcript:
         worker = self._ensure_worker(blocking=False)
@@ -257,16 +285,20 @@ class LocalFinalSTT:
                 samples, language=asked_for, beam_size=self._beam_size
             )
         except Exception as exc:  # noqa: BLE001 — classified as crossable below
+            failure = f"{type(exc).__name__}: {exc}"
             with self._spawn_lock:
-                self._drop_worker_locked()
-                self._next_attempt_at = time.monotonic() + _RETRY_AFTER_S
-                self._last_refusal = f"{type(exc).__name__}: {exc}"
+                # A late failure from a replaced worker must not retire the
+                # replacement or overwrite its healthy readiness state.
+                if self._worker is worker:
+                    self._drop_worker_locked()
+                    self._next_attempt_at = time.monotonic() + _RETRY_AFTER_S
+                    self._last_refusal = failure
             log.warning(
                 "Local dictation worker failed (%s) — replaced; this call crosses "
                 "to the next provider.",
-                self._last_refusal,
+                failure,
             )
-            raise LocalEngineUnavailable(self._last_refusal) from exc
+            raise LocalEngineUnavailable(failure) from exc
         # Whisper segment texts carry their own leading space, so a bare join
         # reproduces the decoder's spacing (a " " join would double it).
         text = "".join(str(getattr(seg, "text", "") or "") for seg in segments).strip()
@@ -318,8 +350,7 @@ class LocalFinalSTT:
             return self._worker  # set once, never mutated in place
         if not self._spawn_lock.acquire(blocking=blocking):
             raise LocalEngineUnavailable(
-                "the local dictation engine is still starting; this call goes "
-                "to the next provider"
+                "the local dictation engine is still starting; this call goes to the next provider"
             )
         try:
             return self._spawn_worker_locked()
@@ -351,7 +382,7 @@ class LocalFinalSTT:
             self._last_refusal = "the dictation worker did not come up"
             return None
         device = str(getattr(worker, "device", "") or "")
-        if device == "cpu":
+        if device == "cpu" and not self._allow_cpu:
             # A beam-search turbo decode of a 25 s window on a CPU takes
             # longer than the cloud round-trip it would replace; the
             # preview keeps its own CPU floor, the final pass does not.
@@ -387,7 +418,7 @@ class LocalFinalSTT:
                 return "the local speech engine (faster-whisper) is not installed here"
         except Exception as exc:  # noqa: BLE001 — a broken probe reads as "absent"
             return f"the local engine probe failed ({type(exc).__name__}: {exc})"
-        if self._min_free_gb <= 0.0:
+        if self._allow_cpu or self._min_free_gb <= 0.0:
             return ""
         try:
             from jarvis.hardware.detection import free_accelerator_gb

--- a/jarvis/dictation/local_preview.py
+++ b/jarvis/dictation/local_preview.py
@@ -174,19 +174,32 @@ class _WorkerModel:
         return segments, info
 
     def close(self) -> None:
-        """Kill the worker. Never raises — this runs on drop/replace paths."""
+        """Kill and reap the worker. Blocking: callers must keep this off-loop."""
         try:
             self._proc.kill()
         except Exception as exc:  # noqa: BLE001 — an already-dead worker is the goal state
             log.debug("Preview worker kill skipped: %s", exc)
+        try:
+            wait = getattr(self._proc, "wait", None)
+            if callable(wait):
+                wait(timeout=3.0)
+        except Exception as exc:  # noqa: BLE001 — never wait forever on teardown
+            log.warning("Preview worker did not exit after kill: %s", exc)
+            return
+        for stream in (self._proc.stdin, self._proc.stdout):
+            if stream is not None:
+                try:
+                    stream.close()
+                except Exception as exc:  # noqa: BLE001 — already-closed pipe is harmless
+                    log.debug("Preview worker pipe close skipped: %s", exc)
 
 
 def _spawn_worker_model(model_name: str, *, compute: str | None = None) -> _WorkerModel | None:
     """Start the out-of-process engine; ``None`` when this host cannot.
 
-    A refused spawn is not an error — the caller falls back to the in-process
-    CPU floor, which never touches the CUDA DLLs and therefore never holds
-    the loader lock. ``compute`` pins the CUDA compute type for the worker
+    A refused spawn disables the decorative preview; final STT retains its
+    authorized fallback policy. No native engine is loaded into the parent.
+    ``compute`` pins the CUDA compute type (or the CPU floor) for the worker
     (the dictation final pass shares the card and asks for ``int8_float16``).
     """
     from jarvis.core.process_utils import NO_WINDOW_CREATIONFLAGS
@@ -195,6 +208,7 @@ def _spawn_worker_model(model_name: str, *, compute: str | None = None) -> _Work
     argv = [_child_python(), "-X", "utf8", "-m", "jarvis.dictation.preview_worker", model_name]
     if compute:
         argv.append(compute)
+    started = time.perf_counter()
     try:
         proc = subprocess.Popen(  # noqa: S603 — our own interpreter + module, no user input
             argv,
@@ -220,13 +234,16 @@ def _spawn_worker_model(model_name: str, *, compute: str | None = None) -> _Work
             result["exc"] = exc
         done.set()
 
-    threading.Thread(target=_handshake, name="dictation-preview-handshake", daemon=True).start()
+    spawned_ms = (time.perf_counter() - started) * 1000.0
+    reader = threading.Thread(target=_handshake, name="dictation-preview-handshake", daemon=True)
+    reader.start()
     if not done.wait(_WORKER_BOOT_TIMEOUT_S):
         log.info(
             "Dictation preview worker did not become ready within %.0f s — killed.",
             _WORKER_BOOT_TIMEOUT_S,
         )
-        proc.kill()
+        _WorkerModel(proc, "", "").close()
+        reader.join(timeout=3.0)
         return None
     message = result.get("msg")
     if not isinstance(message, dict) or not message.get("ready"):
@@ -236,8 +253,16 @@ def _spawn_worker_model(model_name: str, *, compute: str | None = None) -> _Work
             else result.get("exc") or "worker exited during startup"
         )
         log.info("Dictation preview worker reported no engine (%s).", detail)
-        proc.kill()
+        _WorkerModel(proc, "", "").close()
+        reader.join(timeout=3.0)
         return None
+    reader.join(timeout=3.0)
+    log.info(
+        "Dictation worker startup: spawn=%.0f ms, ready=%.0f ms, stages=%s.",
+        spawned_ms,
+        (time.perf_counter() - started) * 1000.0,
+        message.get("timings", {}),
+    )
     return _WorkerModel(
         proc,
         str(message.get("device", "?") or "?"),
@@ -284,6 +309,9 @@ class LocalPreviewTranscriber:
         self._unavailable = False
         self._loading = False
         self._load_failed = False
+        self._load_task: asyncio.Task | None = None
+        self._cleanup_task: asyncio.Task | None = None
+        self._load_timings: dict[str, float] = {}
         #: Language of the MOST RECENT preview, as ``(code, probability)``.
         #: The engine computes this on every call and it used to be discarded.
         #: It is the only reading of the spoken language taken from the AUDIO
@@ -308,10 +336,15 @@ class LocalPreviewTranscriber:
     def _load_model(self) -> None:
         """Build the engine. Runs OFF the transcribe path — see ``transcribe``."""
         try:
-            from jarvis.plugins.stt.fwhisper import _new_whisper_model
-
             if self._prefer_worker:
-                worker = _spawn_worker_model(self._model_name)
+                # Recovery must advance the WORKER'S device ladder too. Resetting
+                # the child to its default recreated the same wedged GPU forever.
+                compute = (None, "int8_float16", "cpu")[min(self._attempt_index, 2)]
+                worker = (
+                    _spawn_worker_model(self._model_name, compute=compute)
+                    if compute
+                    else _spawn_worker_model(self._model_name)
+                )
                 if worker is not None:
                     with self._lock:
                         self._model = worker
@@ -324,15 +357,22 @@ class LocalPreviewTranscriber:
                         worker.compute,
                     )
                     return
-                # No worker on this host: stay on the CPU floor IN process.
-                # Deliberately never CUDA here — the in-process cublas load
-                # holds the Windows loader lock for 15-30 s on a cold boot,
-                # which is the freeze this worker exists to remove.
-                preferred = ("cpu", "int8")
+                # A decorative preview must never defeat process isolation
+                # because its worker failed. Final STT retains the recording.
+                self._load_failed = True
+                self._unavailable = True
+                log.info("Local preview unavailable: isolated worker could not start.")
+                return
             else:
-                preferred = self._pick_device()
+                probe_started = time.perf_counter()
+                preferred = (
+                    ("cpu", "int8") if self._compute_override == "cpu" else self._pick_device()
+                )
+                self._load_timings["probe_ms"] = (time.perf_counter() - probe_started) * 1000.0
                 if self._compute_override and preferred[0] == "cuda":
                     preferred = ("cuda", self._compute_override)
+            from jarvis.plugins.stt.fwhisper import _new_whisper_model
+
             attempts = [preferred]
             if preferred == ("cuda", "float16"):
                 # The quantized pair is the old GPU default and still the
@@ -348,7 +388,9 @@ class LocalPreviewTranscriber:
             last_error: Exception | None = None
             for device, compute in attempts:
                 try:
+                    build_started = time.perf_counter()
                     model = _new_whisper_model(self._model_name, device, compute)
+                    self._load_timings["build_ms"] = (time.perf_counter() - build_started) * 1000.0
                 except Exception as exc:  # noqa: BLE001 — try the portable floor
                     last_error = exc
                     log.info(
@@ -370,10 +412,7 @@ class LocalPreviewTranscriber:
 
                     rng = np.random.default_rng(0)
                     warm_audio = (
-                        rng.standard_normal(int(16_000 * _WARM_CLIP_S)).astype(
-                            np.float32
-                        )
-                        * 0.001
+                        rng.standard_normal(int(16_000 * _WARM_CLIP_S)).astype(np.float32) * 0.001
                     )
                     started = time.perf_counter()
                     segments, _info = model.transcribe(
@@ -384,11 +423,11 @@ class LocalPreviewTranscriber:
                     )
                     list(segments)
                     warm_s = time.perf_counter() - started
+                    self._load_timings["first_decode_ms"] = warm_s * 1000.0
                 except Exception as exc:  # noqa: BLE001 — try the portable floor
                     last_error = exc
                     log.info(
-                        "Dictation preview rejected %s after its first "
-                        "decode failed (%s: %s).",
+                        "Dictation preview rejected %s after its first decode failed (%s: %s).",
                         device,
                         type(exc).__name__,
                         exc,
@@ -399,8 +438,7 @@ class LocalPreviewTranscriber:
                     self._engine_device = device
                     self._engine_compute = compute
                 log.info(
-                    "Dictation preview engine ready: %s on %s (%s), %.0fs clip "
-                    "in %.2fs.",
+                    "Dictation preview engine ready: %s on %s (%s), %.0fs clip in %.2fs.",
                     self._model_name,
                     device,
                     compute,
@@ -439,7 +477,7 @@ class LocalPreviewTranscriber:
 
             ensure_cuda_libraries_findable()
             with inference_only_import_shield():
-                import ctranslate2
+                import ctranslate2  # type: ignore[import-untyped]
 
             supported = set(ctranslate2.get_supported_compute_types("cuda"))
             # Plain half precision first: on the one GPU measured so far the
@@ -456,7 +494,9 @@ class LocalPreviewTranscriber:
             log.debug("Preview CUDA probe failed (%s); using CPU.", exc)
         return "cpu", "int8"
 
-    def _transcribe_sync(self, pcm: bytes, language: str | None) -> tuple[str, str, float]:
+    def _transcribe_sync(
+        self, pcm: bytes, language: str | None, *, model: Any = None
+    ) -> tuple[str, str, float]:
         """``(text, language_code, language_probability)``.
 
         The language is reported back rather than dropped: it costs nothing
@@ -464,11 +504,13 @@ class LocalPreviewTranscriber:
         which no downstream text inspection can reconstruct once a provider
         has translated the words.
         """
-        text, detected, probability, _timings = self._transcribe_sync_detailed(pcm, language)
+        text, detected, probability, _timings = self._transcribe_sync_detailed(
+            pcm, language, model=model
+        )
         return text, detected, probability
 
     def _transcribe_sync_detailed(
-        self, pcm: bytes, language: str | None, *, beam_size: int = 1
+        self, pcm: bytes, language: str | None, *, beam_size: int = 1, model: Any = None
     ) -> tuple[str, str, float, list[dict[str, Any]]]:
         """:meth:`_transcribe_sync` plus the decoder's own segment timings.
 
@@ -483,7 +525,7 @@ class LocalPreviewTranscriber:
         samples = np.frombuffer(pcm, dtype=np.int16).astype(np.float32) / 32768.0
         if samples.size == 0:
             return "", "", 0.0, []
-        model = self._model
+        model = self._model if model is None else model
         if model is None:  # pragma: no cover — transcribe() gates on ready
             return "", "", 0.0, []
         segments, info = model.transcribe(
@@ -550,7 +592,7 @@ class LocalPreviewTranscriber:
         release_here = True
         try:
             work = asyncio.create_task(
-                asyncio.to_thread(self._transcribe_sync, pcm, language),
+                asyncio.to_thread(self._transcribe_sync, pcm, language, model=self._model),
                 name="dictation-local-preview",
             )
             text, detected, probability = await asyncio.wait_for(
@@ -592,7 +634,8 @@ class LocalPreviewTranscriber:
                         # It came back late, but it came back: a slow engine is
                         # not a wedged one, and the streak that would have
                         # dropped it is over.
-                        self._failures = 0
+                        if self._busy is guard:
+                            self._failures = 0
 
                 work.add_done_callback(_release_finished_worker)
             if release_here:
@@ -604,9 +647,26 @@ class LocalPreviewTranscriber:
             if self._loading or self._model is not None or self._load_failed:
                 return
             self._loading = True
-        threading.Thread(
-            target=self._load_model, name="dictation-preview-load", daemon=True
-        ).start()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            threading.Thread(
+                target=self._load_model, name="dictation-preview-load", daemon=True
+            ).start()
+            return
+
+        async def load() -> None:
+            try:
+                if self._cleanup_task is not None:
+                    await asyncio.shield(self._cleanup_task)
+                await asyncio.to_thread(self._load_model)
+            except Exception:
+                self._loading = False
+                self._load_failed = True
+                self._unavailable = True
+                log.exception("Dictation preview background load failed")
+
+        self._load_task = loop.create_task(load(), name="dictation-preview-load")
 
     def _note_failure(self, why: str) -> None:
         """Count a failure and drop the engine once they persist.
@@ -645,7 +705,19 @@ class LocalPreviewTranscriber:
         # in-process model has no close() and is left to the GC as before.
         close = getattr(dropped, "close", None)
         if callable(close):
-            close()
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                close()
+            else:
+
+                async def cleanup() -> None:
+                    try:
+                        await asyncio.to_thread(close)
+                    except Exception:
+                        log.exception("Dictation preview cleanup failed")
+
+                self._cleanup_task = loop.create_task(cleanup(), name="dictation-preview-cleanup")
         log.info(
             "Dictation preview engine dropped (%s on %s/%s); rebuilding on the "
             "next tick with the next engine.",

--- a/jarvis/dictation/preview_worker.py
+++ b/jarvis/dictation/preview_worker.py
@@ -97,6 +97,7 @@ def serve(stdin: IO[bytes], stdout: IO[bytes], model_name: str, compute: str | N
             "ready": True,
             "device": engine._engine_device,  # noqa: SLF001
             "compute": engine._engine_compute,  # noqa: SLF001
+            "timings": getattr(engine, "_load_timings", {}),
         },
     )
     while True:

--- a/jarvis/speech/local_models.py
+++ b/jarvis/speech/local_models.py
@@ -33,8 +33,10 @@ Design contract, mirroring ``jarvis.setup.model_report``:
 - **Capability, never hardware or provider names** (AP-21). Nothing here asks
   what GPU is installed or which vendor a provider belongs to.
 """
+
 from __future__ import annotations
 
+import ast
 import importlib.util
 import logging
 import os
@@ -237,12 +239,40 @@ def whisper_model_cached(name: str) -> bool:
     if not name.strip():
         return False
     try:
-        from faster_whisper.utils import (  # type: ignore[import-not-found,import-untyped]
-            download_model,
-        )
+        directory = Path(name)
+        if not directory.is_dir():
+            # Importing even faster_whisper.utils executes the package initializer
+            # and loads CTranslate2/Transformers. Read its literal alias table as
+            # data instead, so status polls never initialize inference (RUB-37).
+            repo_id = name
+            if "/" not in name:
+                spec = importlib.util.find_spec("faster_whisper")
+                if spec is None or spec.origin is None:
+                    return False
+                source = Path(spec.origin).with_name("utils.py").read_text(encoding="utf-8")
+                aliases = {}
+                for node in ast.parse(source).body:
+                    if isinstance(node, ast.Assign) and any(
+                        isinstance(target, ast.Name) and target.id == "_MODELS"
+                        for target in node.targets
+                    ):
+                        aliases = ast.literal_eval(node.value)
+                        break
+                repo_id = aliases.get(name, "")
+                if not isinstance(repo_id, str) or not repo_id:
+                    return False
+            from huggingface_hub import snapshot_download
 
-        download_model(name, local_files_only=True)
-        return True
+            directory = Path(snapshot_download(repo_id, local_files_only=True))
+        # A snapshot directory alone can be a partial download. The tokenizer
+        # must also be local, otherwise the recognizer fetches one during boot.
+        required = ("config.json", "model.bin", "tokenizer.json")
+        return all(
+            (directory / file).is_file() and (directory / file).stat().st_size > 0
+            for file in required
+        ) and any(
+            file.is_file() and file.stat().st_size > 0 for file in directory.glob("vocabulary.*")
+        )
     except Exception as exc:  # noqa: BLE001 — an uncertain cache is not ready
         log.debug("Whisper checkpoint %r is not cached locally: %s", name, exc)
         return False
@@ -336,9 +366,7 @@ def bundle_present(model_id: str, *, data_dir: str | None = None) -> bool:
     bundle = SHERPA_BUNDLES.get(model_id)
     if bundle is None:
         return False
-    return sherpa_model_present(
-        model_id, data_dir=data_dir, required_files=bundle.required_files
-    )
+    return sherpa_model_present(model_id, data_dir=data_dir, required_files=bundle.required_files)
 
 
 def sherpa_status(
@@ -480,9 +508,7 @@ SHERPA_ONNX_PACKAGE = "sherpa-onnx>=1.13.3"
 #: machine with no GPU), and 560 ms (the middle of the offered 80–1120 ms
 #: chunk sizes: low enough to feel live, long enough that accuracy holds).
 NEMOTRON_MODEL_ID = "nemotron-3.5-asr-streaming-0.6b-560ms-int8"
-NEMOTRON_HF_REPO = (
-    "csukuangfj2/sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11"
-)
+NEMOTRON_HF_REPO = "csukuangfj2/sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-560ms-int8-2026-06-11"
 
 #: Where the sherpa-onnx project publishes its converted TTS voices.
 _PIPER_RELEASE = "https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/"

--- a/jarvis/speech/pipeline.py
+++ b/jarvis/speech/pipeline.py
@@ -10861,7 +10861,7 @@ class SpeechPipeline:
         # wrapper silently handed the voice provider — bias prompt included —
         # back to the dictation lane.
         try:
-            from jarvis.plugins.stt import build_named_stt_provider
+            from jarvis.plugins.stt import build_named_stt_provider, stt_family_id
 
             configured = str(getattr(stt_cfg, "provider", "") or "").strip()
             alternates = list(_resolve_stt_fallback_chain(stt_cfg, configured))
@@ -10886,6 +10886,11 @@ class SpeechPipeline:
                 from jarvis.speech.stt_fallback import FallbackSTT
 
                 chain = [configured, *alternates] if configured else alternates
+                # A local worker cannot fail over to another cold native engine
+                # in the desktop process. Preserve the existing upload policy:
+                # only already-authorized cloud alternates may receive audio.
+                chain = [name for name in chain if stt_family_id(name) != "local"]
+                local_final._allow_cpu = not chain
                 instance = FallbackSTT(
                     local_final,
                     chain,
@@ -11100,6 +11105,15 @@ class SpeechPipeline:
             await self._await_warmup_or_cold_load(task, provider)
             return provider
         except TimeoutError:
+            if getattr(provider, "is_loading", False) and not task.done():
+                # A deadline ends this press's wait, not the worker's native
+                # initialization. Retain its owner so the next press cannot
+                # spawn a second model onto the same device (RUB-37/AP-24).
+                log.warning(
+                    "Dictation engine is still starting after the warm-up "
+                    "deadline; retaining its in-flight load."
+                )
+                return provider
             log.warning(
                 "Dictation STT warm-up did not finish within %.0fs; replacing "
                 "the provider instance before transcription.",

--- a/jarvis/ui/web/provider_routes.py
+++ b/jarvis/ui/web/provider_routes.py
@@ -1504,7 +1504,7 @@ async def _tier_section_health(
     # calling the tier healthy. The real inference test still stays off the
     # page-open path: it would force a multi-gigabyte load for no extra signal.
     if getattr(spec, "auth_mode", None) == "none":
-        local_state = _local_runtime_payload(spec)
+        local_state = await asyncio.to_thread(_local_runtime_payload, spec)
         if local_state is not None and not local_state["ready"]:
             return SectionHealth(
                 status=_section_health.NEEDS_SETUP,

--- a/jarvis/ui/web/schema.py
+++ b/jarvis/ui/web/schema.py
@@ -8,6 +8,7 @@ These models are exported to JSON schema in Phase 1a (via
 `scripts/export_ws_schema.py`) and generated into Zod validators on the
 frontend, so front- and backend stay structurally in sync.
 """
+
 from __future__ import annotations
 
 from dataclasses import asdict, is_dataclass
@@ -22,6 +23,7 @@ from jarvis.safety.command_impact import classify_command
 # ----------------------------------------------------------------------
 # Outgoing (Server → Client)
 # ----------------------------------------------------------------------
+
 
 class WSEventEnvelope(BaseModel):
     """Wraps an arbitrary bus event for transport to the UI.
@@ -70,6 +72,7 @@ class WSAudioLevel(BaseModel):
 # ----------------------------------------------------------------------
 # Incoming (Client → Server)
 # ----------------------------------------------------------------------
+
 
 class WSMessageIn(BaseModel):
     """User message from the UI — text chat, voice transcript, or action."""
@@ -187,6 +190,14 @@ def event_to_ws_envelope(event: Event) -> dict[str, Any]:
         payload[k] = _jsonable(v)
 
     _enrich_shell_impact(event, payload)
+
+    # The bus also uses ready=True to release boot waiters in degraded mode.
+    # A browser's ready flag promises speech is usable, so transport the same
+    # stricter capability that the desktop overlay and boot harness consume.
+    from jarvis.core.events import VoiceBootStatus
+
+    if isinstance(event, VoiceBootStatus):
+        payload["ready"] = event.voice_usable
 
     envelope = WSEventEnvelope(
         event_name=type(event).__name__,

--- a/jarvis/ui/web/server.py
+++ b/jarvis/ui/web/server.py
@@ -670,7 +670,7 @@ class WebServer:
         async def _track_voice_ready(event: VoiceBootStatus) -> None:
             # A bus subscriber must never raise (AP-18); setting a plain
             # instance bool cannot fail, and the warm-up below only schedules.
-            self._voice_ready = bool(event.ready)
+            self._voice_ready = event.voice_usable
             if event.ready:
                 self._schedule_anyio_pool_warm()
 
@@ -719,7 +719,7 @@ class WebServer:
         asyncio.create_task(_warm(), name="anyio-pool-warm")
 
     async def _voice_ready_watchdog(self, deadline_s: float = 45.0) -> None:
-        """Guarantee the UI never hangs on "starting up" forever.
+        """Release boot waiters after a failed warm-up without promising speech.
 
         The startup banner + "STARTING…" status flip to listening ONLY when a
         ``VoiceBootStatus(ready=True)`` arrives (mirrored by /api/voice/status).
@@ -728,7 +728,7 @@ class WebServer:
         published and the banner sticks forever even though the user can already
         type (permanent "Getting ready to listen"). This backstop fires once,
         well past a healthy cold boot (voice-usable budget ≤ 20 s, AP-26), and
-        force-releases the UI. A genuine ready flips ``_voice_ready`` first, in
+        releases boot waiters. A genuine ready flips ``_voice_ready`` first, in
         which case this is a silent no-op. ``detail="watchdog_timeout"`` marks the
         signal as a degraded release (voice may be offline until restart), not a
         real "you can speak now".
@@ -742,13 +742,13 @@ class WebServer:
         logger.warning(
             "Voice-ready watchdog fired after {:.0f}s — the speech pipeline never "
             "signalled ready (a construction crash or a wedged warm-up load). "
-            "Force-releasing the UI from 'starting up'; voice may be offline until "
-            "restart.",
+            "Releasing boot waiters; voice remains unavailable until the pipeline "
+            "confirms listening.",
             deadline_s,
         )
         # Set the endpoint mirror first so /api/voice/status is correct even if
         # the bus publish below fails; the WS event then updates live tabs.
-        self._voice_ready = True
+        self._voice_ready = False
         try:
             await self.bus.publish(VoiceBootStatus(ready=True, detail="watchdog_timeout"))
         except Exception as exc:  # noqa: BLE001 — mirror already set; never crash

--- a/tests/contract/test_cold_voice_readiness.py
+++ b/tests/contract/test_cold_voice_readiness.py
@@ -1,0 +1,30 @@
+"""The REST/WS readiness promises match the desktop capability on every OS."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from jarvis.core.bus import EventBus
+from jarvis.core.config import JarvisConfig
+from jarvis.core.events import VoiceBootStatus
+from jarvis.ui.web.schema import event_to_ws_envelope
+from jarvis.ui.web.server import WebServer
+
+
+@pytest.mark.asyncio
+async def test_ready_transport_matches_actual_voice_capability(monkeypatch):
+    monkeypatch.delenv("JARVIS_VOICE", raising=False)
+    bus = EventBus()
+    server = WebServer(JarvisConfig(), bus=bus)
+    client = TestClient(server.app)
+    for detail, ready, expected in [
+        ("warmup_start", False, False),
+        ("watchdog_timeout", True, False),
+        ("voice_unavailable", True, False),
+        ("listening", True, True),
+        ("warmup_start", False, False),
+    ]:
+        event = VoiceBootStatus(ready=ready, detail=detail)
+        await bus.publish(event)
+        assert event_to_ws_envelope(event)["payload"]["ready"] is expected
+        assert client.get("/api/voice/status").json()["ready"] is expected
+        assert event.voice_usable is expected

--- a/tests/unit/brain/test_refresh_tools_off_loop.py
+++ b/tests/unit/brain/test_refresh_tools_off_loop.py
@@ -1,0 +1,74 @@
+"""Slow plugin discovery cannot block requests or publish half a tool set."""
+
+import asyncio
+import threading
+
+import pytest
+
+from jarvis.brain.manager import BrainManager
+from jarvis.brain.tool_surface import reconcile_tool_surface_async
+
+
+@pytest.mark.asyncio
+async def test_refresh_is_off_loop_coalesced_and_published_atomically(monkeypatch):
+    manager = BrainManager.__new__(BrainManager)
+    manager._tools = {"old": object()}
+    manager._local_action_tools = {}
+    entered, release = threading.Event(), threading.Event()
+    loop_thread = threading.get_ident()
+    builds = []
+    applied = []
+
+    def build():
+        assert threading.get_ident() != loop_thread
+        builds.append(1)
+        entered.set()
+        assert release.wait(3)
+        return {"new": object()}, {"action": object()}
+
+    def apply(snapshot):
+        assert threading.get_ident() == loop_thread
+        applied.append(snapshot)
+        manager._tools, manager._local_action_tools = snapshot
+
+    monkeypatch.setattr(manager, "_build_tool_snapshot", build)
+    monkeypatch.setattr(manager, "_apply_tool_snapshot", apply)
+    first = asyncio.create_task(manager.refresh_tools_async())
+    followers = []
+    try:
+        for _ in range(100):
+            if entered.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert entered.is_set()
+        followers = [asyncio.create_task(manager.refresh_tools_async()) for _ in range(10)]
+        await asyncio.sleep(0.01)
+        assert len(builds) == 1
+        assert list(manager._tools) == ["old"]
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+    finally:
+        release.set()
+        await asyncio.gather(*followers)
+        await manager._tool_refresh_task
+    assert len(builds) == 2  # all mid-build events become one follow-up snapshot
+    assert len(applied) == 2
+    assert list(manager._tools) == ["new"]
+
+
+@pytest.mark.asyncio
+async def test_a_missed_event_is_reconciled_before_the_turn(monkeypatch):
+    import jarvis.brain.tool_surface as surface
+
+    manager = BrainManager.__new__(BrainManager)
+    manager._tool_surface_fp = frozenset({"old"})
+    called = []
+
+    async def refresh():
+        called.append(True)
+
+    monkeypatch.setattr(manager, "refresh_tools_async", refresh)
+    monkeypatch.setattr(surface, "live_tool_surface_fingerprint", lambda: frozenset({"new"}))
+    await reconcile_tool_surface_async(manager)
+    assert called == [True]

--- a/tests/unit/dictation/test_local_final.py
+++ b/tests/unit/dictation/test_local_final.py
@@ -301,6 +301,84 @@ def test_warm_up_spawns_off_the_press_path(_local_ok: dict[str, Any]) -> None:
     assert _local_ok["args"] == [(local_final_mod.DEFAULT_FINAL_MODEL, FINAL_COMPUTE)]
 
 
+@pytest.mark.asyncio
+async def test_cancelled_waiter_keeps_the_pipe_guard_until_reader_exits(_local_ok):
+    entered, release = threading.Event(), threading.Event()
+
+    class SlowWorker(_FakeWorker):
+        def transcribe(self, *args, **kwargs):
+            entered.set()
+            assert release.wait(3)
+            return super().transcribe(*args, **kwargs)
+
+    worker = SlowWorker()
+    stt = LocalFinalSTT()
+    stt._worker = worker
+    task = asyncio.create_task(stt.transcribe_pcm(_pcm()))
+    try:
+        for _ in range(100):
+            if entered.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert entered.is_set()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert worker.closed
+        assert stt._call_lock.locked()
+        assert stt._worker is None
+    finally:
+        release.set()
+        for _ in range(100):
+            if not stt._call_lock.locked():
+                break
+            await asyncio.sleep(0.01)
+    assert not stt._call_lock.locked()
+    assert (await stt.transcribe_pcm(_pcm())).text == "Hallo Welt."
+
+
+def test_local_only_final_pass_keeps_the_isolated_cpu_floor(_local_ok):
+    _local_ok["next"] = _FakeWorker(device="cpu")
+    stt = LocalFinalSTT(allow_cpu=True)
+    assert asyncio.run(stt.transcribe_pcm(_pcm())).text == "Hallo Welt."
+    assert stt.device == "cpu"
+
+
+def test_a_retired_read_cannot_drop_the_replacement(_local_ok, monkeypatch):
+    stt = LocalFinalSTT()
+    replacement = _FakeWorker()
+
+    class RetiredWorker(_FakeWorker):
+        def transcribe(self, *args, **kwargs):
+            stt._worker = replacement
+            raise RuntimeError("old pipe closed")
+
+    stt._worker = RetiredWorker()
+    with pytest.raises(LocalEngineUnavailable):
+        stt._transcribe_blocking(_pcm(), None)
+    assert stt._worker is replacement
+    assert not replacement.closed
+
+
+def test_local_only_chain_does_not_reenter_the_desktop_engine(monkeypatch):
+    import jarvis.dictation.local_preview as preview
+    import jarvis.plugins.stt as plugins
+    import jarvis.speech.pipeline as pipeline
+    import jarvis.speech.stt_dictionary as dictionary
+    from jarvis.core.config import DictationConfig, STTConfig
+
+    monkeypatch.setattr(plugins, "build_stt_from_config", lambda *a, **k: object())
+    monkeypatch.setattr(pipeline, "_resolve_stt_fallback_chain", lambda *a: ())
+    monkeypatch.setattr(dictionary, "wrap_stt_with_dictionary", lambda p: p)
+    monkeypatch.setattr(preview, "faster_whisper_available", lambda: True)
+    pipe = pipeline.SpeechPipeline.__new__(pipeline.SpeechPipeline)
+    pipe._config = SimpleNamespace(stt=STTConfig(provider="faster-whisper"))
+    pipe._dictation_cfg = DictationConfig()
+    provider = pipe._dictation_stt()
+    assert provider._alternate_names == []
+    assert provider._primary._allow_cpu
+
+
 def test_the_lane_puts_the_local_engine_in_front_of_the_configured_provider(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/dictation/test_local_preview.py
+++ b/tests/unit/dictation/test_local_preview.py
@@ -46,7 +46,7 @@ class _Engine(LocalPreviewTranscriber):
         self.calls = 0
         self._model = object()  # pretend the load already completed
 
-    def _transcribe_sync(self, pcm, language):
+    def _transcribe_sync(self, pcm, language, **kwargs):
         self.calls += 1
         if self.error is not None:
             raise self.error
@@ -260,7 +260,7 @@ async def test_a_wedged_native_preview_rotates_to_a_fresh_model_and_guard():
     release = threading.Event()
     engine = _Engine()
 
-    def _wedge(_pcm, _language):
+    def _wedge(_pcm, _language, **kwargs):
         engine.calls += 1
         release.wait(timeout=5.0)
         return "", "", 0.0

--- a/tests/unit/dictation/test_preview_worker.py
+++ b/tests/unit/dictation/test_preview_worker.py
@@ -8,6 +8,7 @@ process. These tests run the protocol in-memory — no subprocess, no model.
 from __future__ import annotations
 
 import io
+from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
@@ -63,7 +64,7 @@ def test_serve_answers_ready_then_transcribes(monkeypatch: pytest.MonkeyPatch) -
     assert serve(stdin, stdout, "base") == 0
 
     ready, first, second = _messages_from(stdout.getvalue())
-    assert ready == {"ready": True, "device": "cpu", "compute": "int8"}
+    assert ready == {"ready": True, "device": "cpu", "compute": "int8", "timings": {}}
     assert first == {
         "text": "heard 200 bytes",
         "language": "de",
@@ -155,11 +156,10 @@ def test_dropping_a_worker_engine_kills_the_process() -> None:
     assert engine._model is None  # noqa: SLF001
 
 
-def test_worker_preferring_load_falls_back_to_the_cpu_floor(
+def test_worker_failure_never_loads_native_code_in_the_parent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """No worker on this host: the in-process build must pin CPU — never the
-    CUDA ladder whose DLL load holds the loader lock."""
+    """A failed decorative preview must not import inference into the parent."""
     from jarvis.plugins.stt import fwhisper
 
     built: list[tuple[str, str]] = []
@@ -178,8 +178,9 @@ def test_worker_preferring_load_falls_back_to_the_cpu_floor(
 
     engine._load_model()  # noqa: SLF001
 
-    assert built == [("cpu", "int8")]
-    assert engine.ready
+    assert built == []
+    assert not engine.ready
+    assert not engine.available
 
 
 def test_the_factory_defaults_to_the_worker_hosting(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -192,3 +193,19 @@ def test_the_factory_defaults_to_the_worker_hosting(monkeypatch: pytest.MonkeyPa
         assert engine._prefer_worker is True  # noqa: SLF001
     finally:
         local_preview_mod.reset_local_preview_for_tests()
+
+
+def test_worker_recovery_advances_to_another_compute_mode(monkeypatch):
+    attempts = []
+
+    def spawn(name, *, compute=None):
+        attempts.append(compute)
+        return SimpleNamespace(device="cuda", compute=compute or "float16", close=lambda: None)
+
+    monkeypatch.setattr(local_preview_mod, "_spawn_worker_model", spawn)
+    engine = LocalPreviewTranscriber(prefer_worker=True)
+    for _ in range(3):
+        engine._load_model()
+        for _ in range(3):
+            engine._note_failure("timed out")
+    assert attempts == [None, "int8_float16", "cpu"]

--- a/tests/unit/dictation/test_warmup_cold_load_patience.py
+++ b/tests/unit/dictation/test_warmup_cold_load_patience.py
@@ -109,3 +109,26 @@ async def test_an_endless_build_eventually_gives_up() -> None:
             await _join(task, provider)
     finally:
         task.cancel()
+
+
+async def test_expired_join_does_not_spawn_a_second_native_build(monkeypatch):
+    from jarvis.speech.pipeline import SpeechPipeline
+
+    provider = _LocalProvider()
+    task = asyncio.create_task(asyncio.sleep(30))
+    pipe = SpeechPipeline.__new__(SpeechPipeline)
+    pipe._dictation_stt_instance = provider
+    pipe._dictation_warmup_task = task
+    pipe._dictation_warmup_provider = provider
+
+    async def expired(*args):
+        raise TimeoutError
+
+    monkeypatch.setattr(pipe, "_await_warmup_or_cold_load", expired)
+    try:
+        assert await pipe._join_dictation_warmup(provider) is provider
+        assert pipe._dictation_stt_instance is provider
+        assert not task.cancelled()
+        assert pipe._dictation_warmup_task is task
+    finally:
+        task.cancel()

--- a/tests/unit/speech/test_cold_model_status.py
+++ b/tests/unit/speech/test_cold_model_status.py
@@ -1,0 +1,73 @@
+"""Cold status queries must not initialize an inference runtime or block HTTP."""
+
+import asyncio
+import sys
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from jarvis.speech import local_models
+
+
+@pytest.mark.parametrize(
+    "missing", [None, "config.json", "model.bin", "tokenizer.json", "vocabulary.json"]
+)
+def test_local_cache_requires_complete_files(tmp_path, missing):
+    for name in ("config.json", "model.bin", "tokenizer.json", "vocabulary.json"):
+        if name != missing:
+            (tmp_path / name).write_text("fixture", encoding="utf-8")
+    assert local_models.whisper_model_cached(str(tmp_path)) is (missing is None)
+
+
+def test_alias_probe_reads_installed_mapping_without_executing_it(tmp_path, monkeypatch):
+    import huggingface_hub
+
+    package = tmp_path / "faster_whisper"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "raise AssertionError('inference imported')", encoding="utf-8"
+    )
+    (package / "utils.py").write_text(
+        "import torch\n_MODELS = {'turbo': 'custom/turbo'}", encoding="utf-8"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.delitem(sys.modules, "faster_whisper", raising=False)
+    seen = []
+
+    def snapshot(repo, **kwargs):
+        seen.append((repo, kwargs))
+        return str(tmp_path / "partial")
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", snapshot)
+    assert local_models.whisper_model_cached("turbo") is False
+    assert seen == [("custom/turbo", {"local_files_only": True})]
+    assert "faster_whisper" not in sys.modules
+
+
+@pytest.mark.asyncio
+async def test_slow_status_disk_check_does_not_block_the_loop(monkeypatch):
+    from jarvis.ui.web import provider_routes
+
+    entered, release = threading.Event(), threading.Event()
+    loop_thread = threading.get_ident()
+
+    def slow_check(spec):
+        assert threading.get_ident() != loop_thread
+        entered.set()
+        assert release.wait(3)
+        return {"ready": True}
+
+    monkeypatch.setattr(provider_routes, "_local_runtime_payload", slow_check)
+    spec = SimpleNamespace(auth_mode="none", id="local", label="Local")
+    task = asyncio.create_task(provider_routes._tier_section_health(None, spec))
+    try:
+        for _ in range(100):
+            if entered.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert entered.is_set()
+        assert not task.done()
+    finally:
+        release.set()
+        await task

--- a/tests/unit/speech/test_local_models.py
+++ b/tests/unit/speech/test_local_models.py
@@ -63,22 +63,22 @@ def test_engine_and_weights_present_is_ready(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_whisper_cache_probe_never_reaches_the_network(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
     """The probe must ask the cache only — a status poll may not start a download."""
     seen: dict[str, object] = {}
 
     def _fake_download(name: str, **kwargs: object) -> str:
         seen.update(kwargs)
-        return name
+        return str(tmp_path)
 
-    monkeypatch.setitem(
-        __import__("sys").modules,
-        "faster_whisper.utils",
-        type("M", (), {"download_model": staticmethod(_fake_download)}),
-    )
+    import huggingface_hub
 
-    assert local_models.whisper_model_cached("large-v3") is True
+    for name in ("config.json", "model.bin", "tokenizer.json", "vocabulary.json"):
+        (tmp_path / name).write_text("fixture", encoding="utf-8")
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", _fake_download)
+
+    assert local_models.whisper_model_cached("test/whisper") is True
     assert seen.get("local_files_only") is True
 
 

--- a/tests/unit/ui/web/test_voice_status_route.py
+++ b/tests/unit/ui/web/test_voice_status_route.py
@@ -73,7 +73,7 @@ async def test_voice_status_tracks_latest_state() -> None:
 
 
 @pytest.mark.asyncio
-async def test_voice_ready_watchdog_force_releases_stuck_ui(monkeypatch) -> None:
+async def test_voice_ready_watchdog_releases_boot_without_claiming_usable(monkeypatch) -> None:
     """Permanent "starting up" backstop: if warm-up never signals ready (a crash
     during pipeline construction or a wedged model load), the watchdog fires
     after its deadline and force-releases the UI so the banner cannot hang
@@ -93,8 +93,8 @@ async def test_voice_ready_watchdog_force_releases_stuck_ui(monkeypatch) -> None
 
     await srv._voice_ready_watchdog(deadline_s=0.01)
 
-    assert srv._voice_ready is True
-    assert any(e.ready and e.detail == "watchdog_timeout" for e in seen)
+    assert srv._voice_ready is False
+    assert any(e.ready and not e.voice_usable and e.detail == "watchdog_timeout" for e in seen)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The cold-start fix is already included in `main` as commit `35975e9c49c86dc914c7fe05faad8add5c41279d`. This PR carried the same change on an isolated branch; a range comparison confirms the only difference is surrounding context in `BrainManager`.

The fix removes heavyweight inference imports from model-status polling, moves tool discovery off the event loop, isolates dictation recovery, preserves in-flight model ownership and reports actual voice readiness to the browser.

Related tracking: RUB-37 / #154. Live cold-start/audio acceptance remains pending, so the issue is not complete.

Validation on the fix branch: 157 targeted tests plus 527 mandatory guard tests passed on Windows. The isolated desktop boot budget passed (window 1.336 s, voice usable 15.016 s, app interactive 15.292 s). GitHub Actions jobs did not start because the account is locked due to a billing issue; these are not successful CI runs.

Closing this redundant PR avoids merging the already-landed patch twice. No branch or code deletion is requested.
