### PR TITLE
chore(repo): let coding agents use their standard Git workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,14 +125,18 @@ history for any of them: `docs/BUGS.md`.
 
 ## 4. How work ships
 
-Commit each finished step (Conventional Commits). Pushing is NOT automatic —
-push only when explicitly asked. `git pull --rebase --ff-only` first if
-origin moved. Never `--force`, never `--no-verify`, never push from a linked or
-mission worktree — the parent lands that work. **A push is `git push`:** nothing
-is built, cloned, audited, or reviewed on the way. Review happens when code is
-written, never when it is published. A check that reads the whole tree belongs
-in CI, never in `pre-push`. A release (SemVer + tag + CHANGELOG + published
-GitHub Release) happens ONLY when explicitly asked.
+Commit each finished step (Conventional Commits). Use the coding agent's
+standard Git workflow: do not artificially leave completed work local, and do
+not wait for extra PersonalJarvis permission to commit, branch, push, or open
+a pull request. `git pull --rebase --ff-only` first if origin moved. Never
+`--force`, never `--no-verify`. Isolated mission workers must not run git
+(`add`/`commit`/`branch`/`checkout`/`push`) — the parent runtime captures the
+diff and lands it. Never push from a linked mission worktree. **A push is
+`git push`:** nothing is built, cloned, audited, or reviewed on the way.
+Review happens when code is written, never when it is published. A check that
+reads the whole tree belongs in CI, never in `pre-push`. A release (SemVer +
+tag + CHANGELOG + published GitHub Release) happens ONLY when explicitly
+asked — an ordinary push is not a release.
 
 Every frontend change works in BOTH light and dark mode, and on the terminal
 panes' own appearance — colours come from theme tokens or the per-appearance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,14 +125,18 @@ history for any of them: `docs/BUGS.md`.
 
 ## 4. How work ships
 
-Commit each finished step (Conventional Commits). Pushing is NOT automatic —
-push only when explicitly asked. `git pull --rebase --ff-only` first if
-origin moved. Never `--force`, never `--no-verify`, never push from a linked or
-mission worktree — the parent lands that work. **A push is `git push`:** nothing
-is built, cloned, audited, or reviewed on the way. Review happens when code is
-written, never when it is published. A check that reads the whole tree belongs
-in CI, never in `pre-push`. A release (SemVer + tag + CHANGELOG + published
-GitHub Release) happens ONLY when explicitly asked.
+Commit each finished step (Conventional Commits). Use the coding agent's
+standard Git workflow: do not artificially leave completed work local, and do
+not wait for extra PersonalJarvis permission to commit, branch, push, or open
+a pull request. `git pull --rebase --ff-only` first if origin moved. Never
+`--force`, never `--no-verify`. Isolated mission workers must not run git
+(`add`/`commit`/`branch`/`checkout`/`push`) — the parent runtime captures the
+diff and lands it. Never push from a linked mission worktree. **A push is
+`git push`:** nothing is built, cloned, audited, or reviewed on the way.
+Review happens when code is written, never when it is published. A check that
+reads the whole tree belongs in CI, never in `pre-push`. A release (SemVer +
+tag + CHANGELOG + published GitHub Release) happens ONLY when explicitly
+asked — an ordinary push is not a release.
 
 Every frontend change works in BOTH light and dark mode, and on the terminal
 panes' own appearance — colours come from theme tokens or the per-appearance

--- a/docs/LLM-CONTEXT.md
+++ b/docs/LLM-CONTEXT.md
@@ -526,7 +526,7 @@ Line length 100. Target `py311`. One per-file `E501` exception (`jarvis/awarenes
 ## 19. Scripts inventory (`scripts/`)
 
 **Cron daemons (production):**
-- `auto-push-eod.ps1` — nightly tag+push crash-backup (primary path is push-after-commit on the shared checkout). Skips worktrees with active Jarvis-Agent session (`<30 min` modify time).
+- `auto-push-eod.ps1` — nightly tag+push crash-backup only; the coding-agent harness owns ordinary Git (`AGENTS.md` §4). Skips worktrees with active Jarvis-Agent session (`<30 min` modify time).
 - `install-auto-push-task.ps1 -Time "22:00"` — register Task Scheduler job.
 - `drift-guard-daemon.ps1` — 5-min config drift defense. Singleton-locked, hidden, started via `shell:startup` shortcut.
 - `install-config-drift-guard-task.ps1` — install variant.

--- a/docs/agent-society/MASTERPLAN.md
+++ b/docs/agent-society/MASTERPLAN.md
@@ -1,6 +1,7 @@
 # Agent Society — Master Plan
 
-Status: **building. Nothing ships or gets pushed until the maintainer says so.** Working
+Status: **building.** Wave landings use the standard Git workflow; a product
+release stays explicit and separate. Working
 codename: `society`; the section keeps the name "Jarvis Agents" (§10).
 
 Progress (2026-09-01/02): **M1 done** — `jarvis/society/` substrate, `/api/society`, the
@@ -330,7 +331,7 @@ add the four controls it lacked: authenticated writes (chokepoint), bounded non-
   World visual identity: see §4.3 — the world carries its own bright game branding and is exempt
   from both Ink & Paper and the Cursor-derived design doc.
 
-## 8. Milestones (~1 month, sequential waves; nothing pushes until the maintainer says so)
+## 8. Milestones (~1 month, sequential waves)
 
 - **M1 — Substrate (T3).** `society.db` (roster/events/knowledge/approvals), typed protocol enums
   (five-layer + parity tests), scheduler with tier wall + budgets + kill switch, mission-event

--- a/docs/agent-society/build-plan-m1-m2.md
+++ b/docs/agent-society/build-plan-m1-m2.md
@@ -42,7 +42,7 @@ Here is the build plan.
 
 All repo paths below are relative to the repository root. (The draft referenced a local Hermes clone at commit `18a76be` as port source; per the revision above nothing is ported from it any more.) The 3D world, society WS, bounded-room *live wiring*, curator, and voice router tool are explicitly **out of scope** (M3/M4).
 
-Ground rules for every wave: commit with explicit pathspecs (`git commit --only -- <paths>`), never `git add -A`; nothing pushes; all committed artifacts English (German/Spanish only inside locale files and `i18n-allow`-marked test quotes); every frontend wave ends with `npm run build` in `jarvis/ui/web/frontend/` (WebView, no F5); every runtime string goes through the `society.*` locale chunk in all three languages; `JarvisAgentsView` stays mounted and green until Wave 8 swaps it.
+Ground rules for every wave: commit with explicit pathspecs (`git commit --only -- <paths>`), never `git add -A`; all committed artifacts English (German/Spanish only inside locale files and `i18n-allow`-marked test quotes); every frontend wave ends with `npm run build` in `jarvis/ui/web/frontend/` (WebView, no F5); every runtime string goes through the `society.*` locale chunk in all three languages; `JarvisAgentsView` stays mounted and green until Wave 8 swaps it.
 
 ---
 

--- a/docs/superpowers/plans/2026-06-16-adjustable-silence-window-slider.md
+++ b/docs/superpowers/plans/2026-06-16-adjustable-silence-window-slider.md
@@ -969,5 +969,5 @@ git commit -m "test(silence-window): e2e verification (chrome-checkup + voice lo
 
 - Use `"/c/Program Files/Python311/python.exe"` for pytest (the Hermes venv `python` has no pytest), per the project memory.
 - The working tree is SHARED across parallel sessions. Stage only this feature's files per commit (the exact `git add` lines above), never `git add -A` except in Task 9 Step 6 where it is scoped to verification artifacts you created.
-- Do NOT commit/push to any remote unless the maintainer asks — these are local commits only.
+- Use the standard Git workflow (`AGENTS.md` §4). An ordinary push is not a release.
 - `_patch_table`, `DEFAULT_CONFIG_FILE`, and `resolve_config_path` already exist in their modules (used by every sibling setter); no new imports beyond what each snippet shows.

--- a/docs/superpowers/plans/2026-06-16-voice-continuation-recombine-while-thinking.md
+++ b/docs/superpowers/plans/2026-06-16-voice-continuation-recombine-while-thinking.md
@@ -13,7 +13,7 @@
 - Pipeline tests build the object via `SpeechPipeline.__new__(SpeechPipeline)` and set only the attributes under test (existing pattern, see the `getattr`-default notes throughout `pipeline.py`). New per-turn pipeline state MUST be read with `getattr(self, "...", default)` so bare instances keep working.
 - Artifacts are English (code, comments, docstrings, commit messages) per `CLAUDE.md`.
 - The working tree is SHARED with parallel sessions. Commit **pathspec-scoped** (only the files each task lists) — never `git add -A`.
-- Do not push. Do not restart the app as part of a task; the go-live restart is called out at the end.
+- Do not restart the app as part of a task; the go-live restart is called out at the end. Use the standard Git workflow (`AGENTS.md` §4); an ordinary push is not a release.
 
 ---
 

--- a/docs/superpowers/plans/2026-06-17-cli-first-tool-selection.md
+++ b/docs/superpowers/plans/2026-06-17-cli-first-tool-selection.md
@@ -15,7 +15,7 @@
 - **No LLM / no network on the gate path** — pure regex + registry lookups (AP-9/AP-11). The new derivation/merge/suppress helpers are pure data transforms.
 - **Every gate/tool-assembly helper degrades gracefully** — any fault returns the safe default (gate → PASS, derivation → `{}`, suppression → unchanged tools); never raises on the voice path.
 - **Python interpreter for tests:** `"C:/Program Files/Python311/python.exe" -m pytest …` (the Hermes-venv `python` has no pytest).
-- **Commits:** local commits only; never push (project rule — pushing is a separate, user-initiated step via the ship skill).
+- **Commits:** Conventional Commits with an explicit pathspec. Use the standard Git workflow (`AGENTS.md` §4); an ordinary push is not a release.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-07-wiki-reliability-pillar-a.md
+++ b/docs/superpowers/plans/2026-07-07-wiki-reliability-pillar-a.md
@@ -33,7 +33,8 @@ fakes in `tests/fakes/` — never `unittest.mock`).
   boot headless on `python:3.11-slim` (Obsidian features degrade to quiet
   no-ops).
 - Git: commit after each task, staging ONLY the files you touched by explicit
-  path (`git add <paths>`), Conventional-Commit messages, never push.
+  path (`git add <paths>`), Conventional-Commit messages. Use the standard
+  Git workflow (`AGENTS.md` §4); an ordinary push is not a release.
 - Working tree is shared with other sessions: never `git add -A`/`git add .`.
 - New worktree? Run `pwsh scripts/preflight.ps1` first (AP-8). Live-app code
   changes take effect only after `POST /api/settings/restart-app`.

--- a/scripts/README-auto-push.md
+++ b/scripts/README-auto-push.md
@@ -2,7 +2,12 @@
 
 ## What does it do?
 
-The **primary** path is live: after each completed commit on the shared primary checkout, agents `git push` (see `docs/agent-contract.md` §2 / §9). This script is the **crash-backup**. It mirrors remaining local branches to GitHub every evening and sets a **backup tag** (`safety/eod-<branchname>-<timestamp>`) first, so a session that died between commit and push still lands, and even destructive follow-up actions stay reversible.
+This script is a **crash-backup**, not the normal Git workflow. Coding-agent
+sessions follow `AGENTS.md`: the harness owns ordinary commits, branches, pushes,
+and pull requests. This script only mirrors remaining local branches to GitHub
+every evening and sets a **backup tag** (`safety/eod-<branchname>-<timestamp>`)
+first, so a session that died between commit and push still lands, and even
+destructive follow-up actions stay reversible.
 
 Background: On 2026-05-01 a restore went well only because you instinctively set backup tags. This automation still does both (tag + push) every evening as the backstop, without you having to think about it.
 
@@ -115,8 +120,13 @@ If you still have uncommitted changes, **the script aborts** (log entry `SKIP: W
 
 ## Clarification: who pushes, and when
 
-Coding agents on the **shared primary checkout** push after each completed commit (`git pull --rebase --ff-only` if origin moved, then `git push`). Never `--force`, never `--no-verify`.
+Normal development Git is owned by the coding-agent harness (`AGENTS.md` §4).
+This script does not define that workflow and does not require a push after
+every commit. Never `--force`, never `--no-verify`.
 
-**Linked worktrees do not push** — mission workers and isolated agent worktrees commit locally; the parent on the primary checkout lands that work. The evening script is the backstop for a crash between commit and push, and for any branch the live path did not reach.
+**Linked mission worktrees do not push** — isolated mission workers must not
+run git; the parent runtime captures the diff and lands it. The evening script
+is the backstop for a crash between commit and push, and for any branch the
+live path did not reach.
 
 The Task Scheduler starts this script as a standalone Windows program (`powershell.exe`), not inside a worker harness, so a worker-tool deny on `git push` does not block the backup.


### PR DESCRIPTION
## What does this PR do?

Removes the repository-wide rule that coding agents may only push when the maintainer explicitly asks. New sessions should use the harness's normal Git workflow. Isolated mission workers still must not run git. Releases stay explicit and separate from an ordinary push.

## Related issue

none

## Everyone

- [x] **English only**
- [x] **One logical change.**
- [x] **No secrets, API keys, or personal data** anywhere in the diff.

## Docs, comments, or translations only

- [x] Nothing else. This is the whole checklist.

## Policy change (for reviewers)

- Canonical `AGENTS.md` / `CLAUDE.md` no longer say `push only when explicitly asked`.
- Mission-worker isolation in `jarvis/missions/worker_runtime/workspace.py` is unchanged.
- `scripts/README-auto-push.md` now describes the evening job as crash-backup only.
- Safety rules remain: never `--force`, never `--no-verify`, secrets/privacy gates stay.
- An ordinary push is still not a release.