### PR TITLE
fix(ci): restore main gates after billing recovery

### DIFF
--- a/jarvis/realtime/session.py
+++ b/jarvis/realtime/session.py
@@ -4226,7 +4226,9 @@ class RealtimeVoiceSession:
         from jarvis.voice.echo_confirmation import classify_response
 
         bridge = self._tool_bridge
-        if bridge is None or not bridge.has_pending_confirmation:
+        if bridge is None or not getattr(
+            bridge, "has_pending_confirmation", False
+        ):
             return False
         stamp = self._last_voiced_input_monotonic
         now = time.monotonic()

--- a/jarvis/society/scheduler.py
+++ b/jarvis/society/scheduler.py
@@ -326,6 +326,7 @@ class SocietyScheduler:
         try:
             await self._deliver(target, env)
         except DeliveryBusy:
+            # Recipient is mid-turn; leave the envelope queued for the next drain.
             return False
         except Exception as exc:  # noqa: BLE001 — persist the failure and report it
             await self._store.mark_delivery(env.event_id, "failed", str(exc))

--- a/jarvis/ui/web/frontend/src/components/society/card/AgentStudioAppearance.tsx
+++ b/jarvis/ui/web/frontend/src/components/society/card/AgentStudioAppearance.tsx
@@ -1,5 +1,6 @@
 import { RotateCcw, Shuffle } from "lucide-react";
 import { useT } from "@/i18n";
+import { BrandedSelect } from "@/components/ui/select";
 import { EDITABLE_CELLS, PALETTE_PRESETS, resolvePalette, shufflePalette, type FigureRecipe } from "../figures/figureRecipe";
 import { CATALOG, catalogBaseFor, isReservedStyle, keepablePartsFor, partsForSlot, slotsWithParts } from "../figures/figureRegistry";
 
@@ -17,16 +18,24 @@ export function AgentStudioAppearance({ recipe, onChange, lead }: {
       <div className="as-note">{t("society.studio.preview_hint")}</div>
       {!lead ? <label className="as-field">
         <span>{t("society.studio.character")}</span>
-        <select value={recipe.model ? "imported" : base?.id ?? `${recipe.archetype}/${recipe.base}`} onChange={(event) => {
-          const next = CATALOG.bases.find((entry) => entry.id === event.target.value);
-          if (!next) return;
-          onChange({ contract: 1, archetype: next.archetype, base: next.base, style: next.styles[0],
-            heightM: next.heightM, palette: { ...next.palette },
-            parts: keepablePartsFor(recipe.parts, next.archetype, next.styles[0], next.family ?? null, next.fitSize) });
-        }}>
-          {recipe.model ? <option value="imported">{t("society.studio.imported")}</option> : null}
-          {CATALOG.bases.filter((entry) => !entry.styles.some(isReservedStyle)).map((entry) => <option key={entry.id} value={entry.id}>{entry.label}</option>)}
-        </select>
+        <BrandedSelect
+          ariaLabel={t("society.studio.character")}
+          value={recipe.model ? "imported" : base?.id ?? `${recipe.archetype}/${recipe.base}`}
+          onValueChange={(value) => {
+            const next = CATALOG.bases.find((entry) => entry.id === value);
+            if (!next) return;
+            onChange({ contract: 1, archetype: next.archetype, base: next.base, style: next.styles[0],
+              heightM: next.heightM, palette: { ...next.palette },
+              parts: keepablePartsFor(recipe.parts, next.archetype, next.styles[0], next.family ?? null, next.fitSize) });
+          }}
+          options={[
+            ...(recipe.model ? [{ value: "imported", label: t("society.studio.imported") }] : []),
+            ...CATALOG.bases.filter((entry) => !entry.styles.some(isReservedStyle)).map((entry) => ({
+              value: entry.id,
+              label: entry.label,
+            })),
+          ]}
+        />
       </label> : null}
       <div className="as-section-title"><h3>{t("society.studio.palette")}</h3>
         <button type="button" className="as-text-button" onClick={() => onChange({ ...recipe, palette: shufflePalette() })}>
@@ -58,11 +67,16 @@ export function AgentStudioAppearance({ recipe, onChange, lead }: {
       <div className="as-grid">
         {slots.map((slot) => <label className="as-field" key={slot}>
           <span>{t(`society.slot.${slot}`)}</span>
-          <select value={recipe.parts[slot] ?? ""} onChange={(event) => onChange({ ...recipe, parts: { ...recipe.parts, [slot]: event.target.value } })}>
-            <option value="">{t("society.studio.none")}</option>
-            {partsForSlot(slot, recipe.archetype, recipe.style ?? null, base?.family ?? null, base?.fitSize ?? null)
-              .map((part) => <option key={part.id} value={part.id}>{part.label}</option>)}
-          </select>
+          <BrandedSelect
+            ariaLabel={t(`society.slot.${slot}`)}
+            value={recipe.parts[slot] ?? ""}
+            onValueChange={(value) => onChange({ ...recipe, parts: { ...recipe.parts, [slot]: value } })}
+            options={[
+              { value: "", label: t("society.studio.none") },
+              ...partsForSlot(slot, recipe.archetype, recipe.style ?? null, base?.family ?? null, base?.fitSize ?? null)
+                .map((part) => ({ value: part.id, label: part.label })),
+            ]}
+          />
         </label>)}
       </div>
       <label className="as-field"><span>{t("society.create.height")} <output>{(recipe.heightM ?? base?.heightM ?? 1.75).toFixed(2)} m</output></span>

--- a/jarvis/ui/web/frontend/src/components/society/card/AgentStudioModel.tsx
+++ b/jarvis/ui/web/frontend/src/components/society/card/AgentStudioModel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check, Save } from "lucide-react";
 import { useT } from "@/i18n";
+import { BrandedSelect } from "@/components/ui/select";
 import { fetchAgentChatCatalog, fetchAgentConnections, fetchProviderModels, type CuratedModel } from "@/lib/agentChatApi";
 import { fetchSocietyProviders, type SocietyAgentRow } from "@/lib/societyApi";
 import { joinProviderOptions } from "@/store/agentChat";
@@ -87,6 +88,7 @@ export function AgentStudioModel({ agent, sample, onGuardChange }: {
   };
   const loading = catalog.isLoading || current.isLoading;
   const failed = catalog.isError || current.isError || live.isError;
+  const fieldsOff = busy || loading || sample || !initial;
   return <div className="as-stack">
     <p className="as-note">{t("society.studio.model_hint")}</p>
     {sample ? <p className="as-note">{t("society.studio.sample")}</p> : null}
@@ -96,16 +98,22 @@ export function AgentStudioModel({ agent, sample, onGuardChange }: {
     </div> : null}
     <fieldset disabled={busy || loading || sample || !initial} className="as-stack">
       <label className="as-field"><span>{t("society.studio.provider")}</span>
-        <select value={selection.provider} onChange={(event) => {
-          const next = seats.find((entry) => entry.provider.id === event.target.value);
-          if (!next) return;
-          const model = next.provider.default_model;
-          const ladder = effortsFor(next, model);
-          change({ provider: next.provider.id, model, effort: ladder.includes(next.provider.default_effort) ? next.provider.default_effort : ladder[0] ?? "", account_id: "" });
-        }}>
-          {!seat ? <option value={selection.provider}>{selection.provider || t("society.card.default_brain")}</option> : null}
-          {seats.map((entry) => <option value={entry.provider.id} key={entry.provider.id}>{entry.provider.label}</option>)}
-        </select>
+        <BrandedSelect
+          ariaLabel={t("society.studio.provider")}
+          value={selection.provider}
+          disabled={fieldsOff}
+          onValueChange={(value) => {
+            const next = seats.find((entry) => entry.provider.id === value);
+            if (!next) return;
+            const model = next.provider.default_model;
+            const ladder = effortsFor(next, model);
+            change({ provider: next.provider.id, model, effort: ladder.includes(next.provider.default_effort) ? next.provider.default_effort : ladder[0] ?? "", account_id: "" });
+          }}
+          options={[
+            ...(!seat ? [{ value: selection.provider, label: selection.provider || t("society.card.default_brain") }] : []),
+            ...seats.map((entry) => ({ value: entry.provider.id, label: entry.provider.label })),
+          ]}
+        />
       </label>
       <label className="as-field"><span>{t("society.chat.model")}</span>
         <input list={`studio-models-${agent.agentId}`} value={selection.model} onChange={(event) => {
@@ -115,18 +123,32 @@ export function AgentStudioModel({ agent, sample, onGuardChange }: {
         <datalist id={`studio-models-${agent.agentId}`}>{models.map((model) => <option key={model.id} value={model.id}>{model.label}</option>)}</datalist>
       </label>
       <label className="as-field"><span>{t("society.chat.effort")}</span>
-        <select value={selection.effort} onChange={(event) => change({ ...selection, effort: event.target.value })}>
-          <option value="">{t("society.chat.effort_default")}</option>
-          {selection.effort && !efforts.includes(selection.effort) ? <option value={selection.effort}>{selection.effort}</option> : null}
-          {efforts.filter(Boolean).map((effort) => <option key={effort} value={effort}>{effort}</option>)}
-        </select>
+        <BrandedSelect
+          ariaLabel={t("society.chat.effort")}
+          value={selection.effort}
+          disabled={fieldsOff}
+          onValueChange={(value) => change({ ...selection, effort: value })}
+          options={[
+            { value: "", label: t("society.chat.effort_default") },
+            ...(selection.effort && !efforts.includes(selection.effort) ? [{ value: selection.effort, label: selection.effort }] : []),
+            ...efforts.filter(Boolean).map((effort) => ({ value: effort, label: effort })),
+          ]}
+        />
       </label>
       {seat?.kind === "subscription" ? <label className="as-field"><span>{t("society.studio.account")}</span>
-        <select value={selection.account_id} onChange={(event) => change({ ...selection, account_id: event.target.value })}>
-          <option value="">{t("society.studio.active_account")}</option>
-          {selection.account_id && !seat.accounts.some((account) => account.id === selection.account_id) ? <option value={selection.account_id}>{t("society.studio.saved_account")}</option> : null}
-          {seat.accounts.map((account) => <option key={account.id} value={account.id}>{account.label}</option>)}
-        </select>
+        <BrandedSelect
+          ariaLabel={t("society.studio.account")}
+          value={selection.account_id}
+          disabled={fieldsOff}
+          onValueChange={(value) => change({ ...selection, account_id: value })}
+          options={[
+            { value: "", label: t("society.studio.active_account") },
+            ...(selection.account_id && !seat.accounts.some((account) => account.id === selection.account_id)
+              ? [{ value: selection.account_id, label: t("society.studio.saved_account") }]
+              : []),
+            ...seat.accounts.map((account) => ({ value: account.id, label: account.label })),
+          ]}
+        />
       </label> : null}
     </fieldset>
     {!loading && !failed && !sample && !seat ? <p className="as-note">{t("society.studio.connect_hint")}</p> : null}

--- a/jarvis/ui/web/frontend/src/components/society/card/agentStudio.css
+++ b/jarvis/ui/web/frontend/src/components/society/card/agentStudio.css
@@ -23,6 +23,7 @@
 .as-field > span { display:flex; justify-content:space-between; gap:10px; }
 .as-field small,.as-note { color:hsl(var(--muted-foreground)); font-size:12px; font-weight:400; line-height:1.6; }
 .as-field input:not([type=range]),.as-field select,.as-field textarea { width:100%; min-width:0; min-height:44px; padding:10px 12px; border:1px solid hsl(var(--border)); border-radius:7px; background:hsl(var(--card)); color:hsl(var(--foreground)); font-size:13px; line-height:1.5; }
+.as-field [role="combobox"] { width:100%; min-width:0; min-height:44px; }
 .as-field textarea { resize:vertical; min-height:150px; }
 .as-field input[type=range] { width:100%; min-height:32px; accent-color:hsl(var(--primary)); }
 .as-note { display:flex; align-items:flex-start; gap:10px; }
@@ -79,6 +80,6 @@
   [data-face=profile] [data-testid=agent-card-figure] { flex-shrink:0; height:320px; }
   .as-header,.as-panel { padding:18px 16px; }
   .as-grid { grid-template-columns:minmax(0,1fr); }
-  .as-field input:not([type=range]),.as-field select,.as-field textarea { font-size:16px; }
+  .as-field input:not([type=range]),.as-field select,.as-field textarea,.as-field [role="combobox"] { font-size:16px; }
   .as-save-status { flex-basis:100%; }
 }

--- a/tests/unit/realtime/test_session.py
+++ b/tests/unit/realtime/test_session.py
@@ -314,6 +314,10 @@ class FakeToolBridge:
         self.calls = []
         self.closed = False
 
+    @property
+    def has_pending_confirmation(self) -> bool:
+        return False
+
     def set_language(self, language):
         self.languages.append(language)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2651,7 +2651,7 @@ wheels = [
 
 [[package]]
 name = "personal-jarvis"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Why

The first real Actions run after the billing lock (https://github.com/PersonalJarvis/PersonalJarvis/actions/runs/34245402732) showed four independent failures on `main`. None of them were billing.

## What changed

- **Silent-handler ratchet:** `except DeliveryBusy` in the society scheduler now says why the envelope stays queued.
- **Frontend native-select guard:** Agent Studio appearance/model dropdowns use `BrandedSelect` instead of `<select>`.
- **Windows realtime session isolation:** the pump was dying on `AttributeError: FakeToolBridge has no attribute has_pending_confirmation`. The session now probes that flag as a capability, and the fake implements it.
- **deps-sync:** `uv.lock` still named the package `2.0.0` after the `2.1.0` release.

T2: existing surfaces, shared contracts unchanged. Desktop `main` was not touched.

## Checks run locally

- `check_silent_exception_handlers.py` OK
- `uv lock --check` OK
- vitest `no-native-selects.test.ts` passed
- the six previously failing `test_session.py` cases + `test_internal_message_regression.py` + silent-handler unit tests: 28 passed
- society scheduler-related unit tests: 21 passed
